### PR TITLE
Phase 4 + Phase 5: Standalone mode, multi-host scenarios, per-step metrics, and session token cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ next_steps.md
 
 # Phase 3 web app design (separate repo — local planning only)
 phase3_web_app/
-
-# Nomad job specs (local infrastructure, not part of the public repo)
-nomad/

--- a/.vscode/grafana-dashboard.json
+++ b/.vscode/grafana-dashboard.json
@@ -3,7 +3,6 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -13,9 +12,8 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
   "links": [],
   "panels": [
     {
@@ -31,12 +29,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
@@ -50,14 +49,19 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rust_loadtest_requests_total",
@@ -80,7 +84,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "yellow",
@@ -93,7 +97,8 @@
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
@@ -107,14 +112,19 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rust_loadtest_concurrent_requests",
@@ -137,12 +147,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "reqps"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
@@ -156,14 +167,19 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rate(rust_loadtest_requests_total[1m])",
@@ -186,7 +202,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -195,7 +211,8 @@
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 4,
@@ -209,14 +226,19 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "sum(rate(rust_loadtest_request_errors_by_category[1m]))",
@@ -234,17 +256,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -252,6 +279,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -267,12 +295,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "reqps"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -283,15 +312,21 @@
       "id": 5,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rate(rust_loadtest_requests_total[1m])",
@@ -315,17 +350,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -333,6 +373,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -348,12 +389,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -364,15 +406,20 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["sum"],
+          "calcs": [
+            "sum"
+          ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "sum by(status_code) (rust_loadtest_requests_status_codes_total)",
@@ -391,17 +438,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -409,6 +461,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -424,7 +477,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "yellow",
@@ -437,7 +490,8 @@
             ]
           },
           "unit": "s"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -448,15 +502,22 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["mean", "max", "lastNotNull"],
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "histogram_quantile(0.50, rate(rust_loadtest_request_duration_seconds_bucket[1m]))",
@@ -495,17 +556,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -513,6 +579,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -528,12 +595,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "reqps"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -544,15 +612,21 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rust_loadtest_scenario_throughput_rps",
@@ -571,17 +645,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -589,6 +668,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -604,12 +684,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -620,15 +701,20 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["sum"],
+          "calcs": [
+            "sum"
+          ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "sum by(scenario, status) (rust_loadtest_scenario_executions_total)",
@@ -647,17 +733,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -665,6 +756,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -680,12 +772,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -696,15 +789,20 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["sum"],
+          "calcs": [
+            "sum"
+          ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "sum by(category) (rate(rust_loadtest_request_errors_by_category[1m]))",
@@ -730,7 +828,7 @@
             "steps": [
               {
                 "color": "red",
-                "value": null
+                "value": 0
               },
               {
                 "color": "yellow",
@@ -743,7 +841,8 @@
             ]
           },
           "unit": "percent"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -753,16 +852,21 @@
       },
       "id": 11,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
         "showThresholdLabels": false,
-        "showThresholdMarkers": true
+        "showThresholdMarkers": true,
+        "sizing": "auto"
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rust_loadtest_connection_pool_reuse_rate_percent",
@@ -780,17 +884,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -798,6 +907,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -813,12 +923,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -829,15 +940,20 @@
       "id": 12,
       "options": {
         "legend": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rate(rust_loadtest_connection_pool_likely_reused_total[1m])",
@@ -861,17 +977,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -879,6 +1000,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -894,12 +1016,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "s"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -910,15 +1033,21 @@
       "id": 13,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "histogram_quantile(0.50, rate(rust_loadtest_scenario_duration_seconds_bucket[1m]))",
@@ -947,17 +1076,22 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
             "hideFrom": {
+              "legend": false,
               "tooltip": false,
-              "viz": false,
-              "legend": false
+              "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -965,6 +1099,7 @@
               "type": "linear"
             },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -980,12 +1115,13 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -996,15 +1132,20 @@
       "id": 14,
       "options": {
         "legend": {
-          "calcs": ["sum"],
+          "calcs": [
+            "sum"
+          ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "right",
+          "showLegend": true
         },
         "tooltip": {
-          "mode": "multi"
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "sum by(scenario, step, status) (rust_loadtest_scenario_assertions_total)",
@@ -1019,27 +1160,54 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 52 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 52
+      },
       "id": 15,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
-      "targets": [{ "expr": "rust_loadtest_workers_configured_total", "refId": "A" }],
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rust_loadtest_workers_configured_total",
+          "refId": "A"
+        }
+      ],
       "title": "Workers Configured",
       "type": "stat"
     },
@@ -1047,29 +1215,56 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
           },
           "unit": "percent"
-        }
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 52 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 52
+      },
       "id": 16,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
-      "targets": [{ "expr": "rust_loadtest_percentile_sampling_rate_percent", "refId": "A" }],
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rust_loadtest_percentile_sampling_rate_percent",
+          "refId": "A"
+        }
+      ],
       "title": "Percentile Sampling Rate",
       "type": "stat"
     },
@@ -1077,12 +1272,22 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [
             {
               "options": {
-                "0": { "color": "red", "index": 0, "text": "DISABLED" },
-                "1": { "color": "green", "index": 1, "text": "ACTIVE" }
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "DISABLED"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "ACTIVE"
+                }
               },
               "type": "value"
             }
@@ -1090,25 +1295,51 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 }
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 52 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 52
+      },
       "id": 17,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
-      "targets": [{ "expr": "rust_loadtest_percentile_tracking_active", "refId": "A" }],
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rust_loadtest_percentile_tracking_active",
+          "refId": "A"
+        }
+      ],
       "title": "Percentile Tracking",
       "type": "stat"
     },
@@ -1116,31 +1347,57 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 52 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 52
+      },
       "id": 18,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
-        { "expr": "rust_loadtest_memory_warning_threshold_exceeded_total", "refId": "A" }
+        {
+          "expr": "rust_loadtest_memory_warning_threshold_exceeded_total",
+          "refId": "A"
+        }
       ],
       "title": "Memory Warnings",
       "type": "stat"
@@ -1149,31 +1406,57 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 52 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 52
+      },
       "id": 19,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
-        { "expr": "rust_loadtest_memory_critical_threshold_exceeded_total", "refId": "A" }
+        {
+          "expr": "rust_loadtest_memory_critical_threshold_exceeded_total",
+          "refId": "A"
+        }
       ],
       "title": "Memory Critical Events",
       "type": "stat"
@@ -1182,31 +1465,57 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 }
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 52 },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 52
+      },
       "id": 20,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
-        { "expr": "rust_loadtest_histogram_labels_evicted_total", "refId": "A" }
+        {
+          "expr": "rust_loadtest_histogram_labels_evicted_total",
+          "refId": "A"
+        }
       ],
       "title": "Histogram Labels Evicted",
       "type": "stat"
@@ -1215,39 +1524,80 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
+            "showValues": false,
             "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 56 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
       "id": 21,
       "options": {
-        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "right" },
-        "tooltip": { "mode": "multi" }
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rust_loadtest_memory_warning_threshold_exceeded_total",
@@ -1277,28 +1627,57 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
           },
           "unit": "short"
-        }
+        },
+        "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 64 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 64
+      },
       "id": 22,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
         "justifyMode": "center",
         "orientation": "auto",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "text": { "valueSize": 80 },
-        "textMode": "auto"
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 80
+        },
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.0.0",
-      "targets": [{ "expr": "rust_loadtest_requests_total", "refId": "A" }],
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "rust_loadtest_requests_total",
+          "refId": "A"
+        }
+      ],
       "title": "Requests Sent",
       "type": "stat"
     },
@@ -1306,76 +1685,56 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
+          "color": {
+            "mode": "continuous-GrYlRd"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
           },
           "unit": "reqps"
-        }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 72 },
-      "id": 23,
-      "options": {
-        "legend": {
-          "calcs": ["last", "mean", "sum"],
-          "displayMode": "table",
-          "placement": "bottom"
         },
-        "tooltip": { "mode": "multi" }
+        "overrides": []
       },
-      "pluginVersion": "9.0.0",
-      "targets": [
-        {
-          "expr": "sum by(status_code) (rate(rust_loadtest_requests_status_codes_total[1m]))",
-          "legendFormat": "{{status_code}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Requests by Response Code",
-      "type": "timeseries"
-    },
-    {
-      "datasource": "Prometheus",
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "continuous-GrYlRd" },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [{ "color": "green", "value": null }]
-          },
-          "unit": "reqps"
-        }
+      "gridPos": {
+        "h": 16,
+        "w": 12,
+        "x": 12,
+        "y": 64
       },
-      "gridPos": { "h": 16, "w": 12, "x": 12, "y": 64 },
       "id": 24,
       "options": {
         "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
         "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "showUnfilled": true,
-        "text": {}
+        "sizing": "auto",
+        "text": {},
+        "valueMode": "color"
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "rate(rust_loadtest_request_duration_seconds_bucket[1m])",
@@ -1390,26 +1749,176 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
-            "drawStyle": "bars",
-            "fillOpacity": 80,
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
             "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
-            "spanNulls": false
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
           },
           "unit": "reqps"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 80 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 72
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "mean",
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "sum by(status_code) (rate(rust_loadtest_requests_status_codes_total[1m]))",
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests by Response Code",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 80
+      },
       "id": 25,
       "options": {
-        "legend": { "calcs": ["mean", "max", "last"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "sum by(region, node_id) (rate(rust_loadtest_requests_total[1m]))",
@@ -1423,10 +1932,26 @@
     {
       "datasource": "Prometheus",
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": {} },
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
         "overrides": []
       },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 88 },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 88
+      },
       "id": 26,
       "options": {
         "calculate": false,
@@ -1440,14 +1965,31 @@
           "scheme": "Oranges",
           "steps": 64
         },
-        "exemplars": { "color": "rgba(255,0,255,0.7)" },
-        "filterValues": { "le": 1e-9 },
-        "legend": { "show": true },
-        "rowsFrame": { "layout": "auto" },
-        "tooltip": { "mode": "multi", "yHistogram": false },
-        "yAxis": { "axisPlacement": "left", "reverse": false, "unit": "s" }
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true,
+          "showLegend": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "sum(rate(rust_loadtest_request_duration_seconds_bucket[1m])) by (le)",
@@ -1463,26 +2005,86 @@
       "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
             "showPoints": "never",
-            "spanNulls": false
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
           },
           "unit": "s"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 98 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 98
+      },
       "id": 27,
       "options": {
-        "legend": { "calcs": ["mean", "max", "last"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
+      "pluginVersion": "12.4.0",
       "targets": [
         {
           "expr": "histogram_quantile(0.50, sum by(region, le) (rate(rust_loadtest_request_duration_seconds_bucket[1m])))",
@@ -1502,23 +2104,413 @@
       ],
       "title": "Latency Percentiles by Region",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 106
+      },
+      "id": 28,
+      "title": "Per-Step Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 107
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "sum by (step, scenario) (rate(rust_loadtest_scenario_steps_total[1m]))",
+          "legendFormat": "{{scenario}} / {{step}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Step RPS by Step",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 107
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "sum by (step, scenario, status_code) (rate(rust_loadtest_scenario_step_status_codes_total[1m]))",
+          "legendFormat": "{{scenario}} / {{step}} \u2014 {{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Step Status Codes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 115
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "100 * sum by (step, scenario) (rate(rust_loadtest_scenario_steps_total{status=\"success\"}[1m])) / sum by (step, scenario) (rate(rust_loadtest_scenario_steps_total[1m]))",
+          "legendFormat": "{{scenario}} / {{step}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Step Success Rate %",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 115
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, step, scenario) (rate(rust_loadtest_scenario_step_duration_seconds_bucket[1m])))",
+          "legendFormat": "{{scenario}} / {{step}} p99",
+          "refId": "A"
+        }
+      ],
+      "title": "Step p99 Latency",
+      "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "5s",
-  "schemaVersion": 36,
-  "style": "dark",
-  "tags": ["rust", "loadtest", "performance"],
+  "schemaVersion": 42,
+  "tags": [
+    "rust",
+    "loadtest",
+    "performance"
+  ],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "browser",
   "title": "Rust LoadTest - Performance Dashboard",
   "uid": "rust-loadtest-dashboard",
-  "version": 4,
+  "version": 2,
   "weekStart": ""
 }

--- a/examples/scenario_example.rs
+++ b/examples/scenario_example.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: cargo run --example scenario_example
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{
     Assertion, Extractor, RequestConfig, Scenario, ScenarioContext, Step, ThinkTime,
     VariableExtraction,
@@ -32,7 +32,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Execute the scenario
     let mut context = ScenarioContext::new();
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // Print results
     println!("\n=== Scenario Execution Results ===");
@@ -96,6 +98,7 @@ fn create_shopping_scenario() -> Scenario {
                 },
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             // Step 2: Browse products and extract first product ID
@@ -119,6 +122,7 @@ fn create_shopping_scenario() -> Scenario {
                     Assertion::StatusCode(200),
                     Assertion::BodyContains("products".to_string()),
                 ],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_secs(2))),
             },
             // Step 3: View product details using extracted product_id
@@ -136,6 +140,7 @@ fn create_shopping_scenario() -> Scenario {
                     Assertion::StatusCode(200),
                     Assertion::ResponseTime(Duration::from_millis(500)),
                 ],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_secs(3))),
             },
             // Step 4: Register user
@@ -166,6 +171,7 @@ fn create_shopping_scenario() -> Scenario {
                     },
                 ],
                 assertions: vec![Assertion::StatusCode(201)],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_secs(1))),
             },
             // Step 5: Add item to cart (using auth token)
@@ -196,6 +202,7 @@ fn create_shopping_scenario() -> Scenario {
                     extractor: Extractor::JsonPath("$.cart.id".to_string()),
                 }],
                 assertions: vec![Assertion::StatusCode(201)],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_secs(2))),
             },
             // Step 6: View cart
@@ -219,6 +226,7 @@ fn create_shopping_scenario() -> Scenario {
                     Assertion::StatusCode(200),
                     Assertion::BodyContains("items".to_string()),
                 ],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_secs(5))),
             },
         ],

--- a/nomad/consul-kv-config-example.yaml
+++ b/nomad/consul-kv-config-example.yaml
@@ -41,7 +41,7 @@ scenarios:
             name: "jwt_token"
             jsonPath: "$.token"
         cache:
-          ttl: "1h"                     # reuse token for 1 hour per worker; re-login on expiry
+          ttl: "3m"                     # reuse token for 1 hour per worker; re-login on expiry
         assertions:
           - type: statusCode
             expected: 200

--- a/nomad/consul-kv-config-example.yaml
+++ b/nomad/consul-kv-config-example.yaml
@@ -15,15 +15,15 @@ metadata:
   description: "Fetch JWT from auth service, use it against API service"
 
 config:
-  baseUrl: "http://auth-service.service.consul:8080"
-  workers: 50
+  baseUrl: "http://192.168.2.23:31362"
+  workers: 25
   duration: "75h"
   timeout: "30s"
   skipTlsVerify: false
 
 load:
   model: "rps"
-  target: 200
+  target: 400
 
 scenarios:
   - name: "JWT Auth → API call"
@@ -32,14 +32,16 @@ scenarios:
       - name: "Login — get JWT"
         request:
           method: "POST"
-          path: "/api/auth/login"           # relative → uses baseUrl (auth service)
-          body: '{"username":"loadtest","password":"secret"}'
+          path: "/auth/login"           # relative → uses baseUrl (auth service)
+          body: '{"email":"test@example.com","password":"password123"}'
           headers:
             Content-Type: "application/json"
         extract:
           - type: jsonPath
             name: "jwt_token"
-            jsonPath: "$.access_token"
+            jsonPath: "$.token"
+        cache:
+          ttl: "1h"                     # reuse token for 1 hour per worker; re-login on expiry
         assertions:
           - type: statusCode
             expected: 200
@@ -47,7 +49,7 @@ scenarios:
       - name: "Call API with JWT"
         request:
           method: "GET"
-          path: "http://api-service.service.consul:9090/api/data"  # full URL → host B
+          path: "http://ecom-test-target.service.consul:31362/users/me"  # full URL → host B
           headers:
             Authorization: "Bearer ${jwt_token}"
         assertions:

--- a/nomad/consul-kv-config-example.yaml
+++ b/nomad/consul-kv-config-example.yaml
@@ -1,0 +1,61 @@
+# Consul KV test config — dual-host JWT auth flow (Issue #82)
+#
+# Upload to Consul KV before deploying the cluster:
+#
+#   consul kv put loadtest/config @nomad/consul-kv-config-example.yaml
+#
+# Demonstrates multi-host steps: step 1 fetches a JWT from the auth service
+# (relative path → baseUrl), step 2 calls the API service using a full URL
+# override.  The extracted jwt_token variable is passed between steps.
+
+version: "1.0"
+
+metadata:
+  name: "Dual-host JWT auth flow"
+  description: "Fetch JWT from auth service, use it against API service"
+
+config:
+  baseUrl: "http://auth-service.service.consul:8080"
+  workers: 50
+  duration: "75h"
+  timeout: "30s"
+  skipTlsVerify: false
+
+load:
+  model: "rps"
+  target: 200
+
+scenarios:
+  - name: "JWT Auth → API call"
+    weight: 100
+    steps:
+      - name: "Login — get JWT"
+        request:
+          method: "POST"
+          path: "/api/auth/login"           # relative → uses baseUrl (auth service)
+          body: '{"username":"loadtest","password":"secret"}'
+          headers:
+            Content-Type: "application/json"
+        extract:
+          - type: jsonPath
+            name: "jwt_token"
+            jsonPath: "$.access_token"
+        assertions:
+          - type: statusCode
+            expected: 200
+
+      - name: "Call API with JWT"
+        request:
+          method: "GET"
+          path: "http://api-service.service.consul:9090/api/data"  # full URL → host B
+          headers:
+            Authorization: "Bearer ${jwt_token}"
+        assertions:
+          - type: statusCode
+            expected: 200
+          - type: responseTime
+            max: "2s"
+
+standby:
+  workers: 2
+  rps: 0

--- a/nomad/loadtest-consul-kv-example.nomad.hcl
+++ b/nomad/loadtest-consul-kv-example.nomad.hcl
@@ -153,7 +153,7 @@ job "envoy-loadtest" {
             gelf-address = "udp://gelf.service.consul:12201"
           }
         }
-        image      = "cbaugus/rust_loadtest:dev-9138374"
+        image      = "cbaugus/rust_loadtest:dev"
         force_pull = true
         ports = [
           "metrics",

--- a/nomad/loadtest-consul-kv-example.nomad.hcl
+++ b/nomad/loadtest-consul-kv-example.nomad.hcl
@@ -153,7 +153,7 @@ job "envoy-loadtest" {
             gelf-address = "udp://gelf.service.consul:12201"
           }
         }
-        image      = "cbaugus/rust_loadtest:dev"
+        image      = "cbaugus/rust_loadtest:dev-43db789"
         force_pull = true
         ports = [
           "metrics",
@@ -171,6 +171,7 @@ job "envoy-loadtest" {
 # runs at startup before the Raft cluster forms and before the leader can fetch
 # from Consul KV.  The values here are replaced cluster-wide as soon as the
 # leader commits the Consul KV config to the Raft log.
+RUST_LOG=rust_loadtest=warn
 TARGET_URL=http://dialtone.service.consul:5678
 REQUEST_TYPE=GET
 SKIP_TLS_VERIFY=true

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -173,7 +173,9 @@ impl ScenarioExecutor {
                 "Executing step"
             );
 
-            let step_result = self.execute_step(&scenario.name, step, context, session).await;
+            let step_result = self
+                .execute_step(&scenario.name, step, context, session)
+                .await;
 
             let success = step_result.success;
             step_results.push(step_result);
@@ -396,7 +398,13 @@ impl ScenarioExecutor {
                                     ttl_secs = cache_cfg.ttl.as_secs(),
                                     "Caching step result in session store"
                                 );
-                                session.insert(step.name.clone(), SessionEntry { variables: vars, expires_at });
+                                session.insert(
+                                    step.name.clone(),
+                                    SessionEntry {
+                                        variables: vars,
+                                        expires_at,
+                                    },
+                                );
                             }
 
                             count
@@ -607,6 +615,7 @@ mod tests {
             error: None,
             assertions_passed: 2,
             assertions_failed: 0,
+            cache_hit: false,
         };
 
         assert!(result.success);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -237,7 +237,11 @@ impl ScenarioExecutor {
 
         // Build the full URL with variable substitution
         let path = context.substitute_variables(&step.request.path);
-        let url = format!("{}{}", self.base_url, path);
+        let url = if path.starts_with("http://") || path.starts_with("https://") {
+            path
+        } else {
+            format!("{}{}", self.base_url, path)
+        };
 
         debug!(
             step = %step.name,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1057,16 +1057,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         handles.push(handle);
     }
 
-    // Wait for the total test duration to pass
-    tokio::time::sleep(config.test_duration).await;
-    info!(
-        duration_secs = config.test_duration.as_secs(),
-        "Test duration completed, signalling workers to stop"
-    );
+    // Wait for the first test to actually complete.
+    //
+    // Previously this was `sleep(config.test_duration)` which used the
+    // startup env-var duration and caused the process to exit early when a
+    // POST /config submitted a longer test (e.g. 72 h vs TEST_DURATION=2 h).
+    //
+    // `spawn_completion_watcher` is now the authoritative timer: it sleeps for
+    // whatever duration the *active* test requires (updated on every POST /config)
+    // and transitions `node_state` to "standby" when done.  We just poll until
+    // that transition happens.
+    loop {
+        let state = test_state.lock().unwrap().node_state;
+        if state != "running" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(10)).await;
+    }
+    info!("Test duration completed, collecting final metrics");
 
     // Brief pause to allow in-flight metrics to be updated
     tokio::time::sleep(Duration::from_secs(2)).await;
-    info!("Collecting final metrics");
 
     // Print percentile latency statistics (Issue #33, #66)
     print_percentile_report(
@@ -1085,9 +1096,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     info!("\n--- FINAL METRICS ---\n{}", final_metrics_output);
     info!("--- END OF FINAL METRICS ---");
 
-    info!("Pausing for 2 minutes to allow final Prometheus scrape");
-    tokio::time::sleep(Duration::from_secs(120)).await;
-    info!("Pause complete, exiting");
+    // Keep the process alive in standby — workers, the health API, and the
+    // Prometheus metrics endpoint remain active until the container is stopped
+    // externally (SIGTERM from Nomad/Docker).  The final-scrape pause is no
+    // longer necessary because Prometheus continues scraping during standby.
+    info!("Standby mode active — process will remain alive until stopped externally");
+    tokio::time::sleep(Duration::from_secs(365 * 24 * 3600)).await;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,12 +27,12 @@ use rust_loadtest::metrics::{
     PERCENTILE_SAMPLING_RATE_PERCENT, PROCESS_MEMORY_RSS_BYTES, REQUEST_ERRORS_BY_CATEGORY,
     REQUEST_TOTAL, WORKERS_CONFIGURED_TOTAL,
 };
+use rust_loadtest::multi_scenario::ScenarioSelector;
 use rust_loadtest::percentiles::{
     format_percentile_table, rotate_all_histograms, GLOBAL_REQUEST_PERCENTILES,
     GLOBAL_SCENARIO_PERCENTILES, GLOBAL_STEP_PERCENTILES,
 };
 use rust_loadtest::throughput::{format_throughput_table, GLOBAL_THROUGHPUT_TRACKER};
-use rust_loadtest::multi_scenario::ScenarioSelector;
 use rust_loadtest::worker::{run_scenario_worker, run_worker, ScenarioWorkerConfig, WorkerConfig};
 use rust_loadtest::yaml_config::YamlConfig;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -77,6 +77,13 @@ lazy_static::lazy_static! {
             &["scenario", "step"]
         ).unwrap();
 
+    pub static ref SCENARIO_STEP_STATUS_CODES: IntCounterVec =
+        IntCounterVec::new(
+            Opts::new("scenario_step_status_codes_total", "HTTP status codes per scenario step")
+                .namespace(METRIC_NAMESPACE.as_str()),
+            &["scenario", "step", "status_code"]
+        ).unwrap();
+
     pub static ref SCENARIO_ASSERTIONS_TOTAL: IntCounterVec =
         IntCounterVec::new(
             Opts::new("scenario_assertions_total", "Total number of scenario assertions")
@@ -272,6 +279,7 @@ pub fn register_metrics() -> Result<(), Box<dyn std::error::Error + Send + Sync>
     prometheus::default_registry().register(Box::new(SCENARIO_DURATION_SECONDS.clone()))?;
     prometheus::default_registry().register(Box::new(SCENARIO_STEPS_TOTAL.clone()))?;
     prometheus::default_registry().register(Box::new(SCENARIO_STEP_DURATION_SECONDS.clone()))?;
+    prometheus::default_registry().register(Box::new(SCENARIO_STEP_STATUS_CODES.clone()))?;
     prometheus::default_registry().register(Box::new(SCENARIO_ASSERTIONS_TOTAL.clone()))?;
     prometheus::default_registry().register(Box::new(CONCURRENT_SCENARIOS.clone()))?;
 

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -99,6 +99,18 @@ impl ThinkTime {
     }
 }
 
+/// Per-worker session cache configuration for a step.
+///
+/// When set, the step's extracted variables are cached in the worker's session
+/// store for the given TTL.  On subsequent scenario iterations the HTTP request
+/// is skipped entirely and the cached values are injected directly — simulating
+/// an app that keeps a long-lived token and only re-authenticates on expiry.
+#[derive(Debug, Clone)]
+pub struct StepCache {
+    /// How long to reuse the cached variables before making a fresh request.
+    pub ttl: Duration,
+}
+
 /// A single step within a scenario.
 #[derive(Debug, Clone)]
 pub struct Step {
@@ -113,6 +125,10 @@ pub struct Step {
 
     /// Assertions to validate the response
     pub assertions: Vec<Assertion>,
+
+    /// Optional session cache: reuse extracted variables for the given TTL
+    /// instead of making a real HTTP request on every scenario iteration.
+    pub cache: Option<StepCache>,
 
     /// Optional delay after this step completes (think time)
     ///
@@ -450,6 +466,7 @@ mod tests {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             }],
         };

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -29,6 +29,7 @@ use std::time::{Duration, Instant};
 ///             },
 ///             extractions: vec![],
 ///             assertions: vec![],
+///             cache: None,
 ///             think_time: Some(ThinkTime::Fixed(Duration::from_secs(2))),
 ///         },
 ///     ],

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -398,7 +398,9 @@ pub async fn run_scenario_worker(
         let mut context = ScenarioContext::new();
 
         // Execute the scenario
-        let result = executor.execute(&config.scenario, &mut context, &mut session).await;
+        let result = executor
+            .execute(&config.scenario, &mut context, &mut session)
+            .await;
 
         debug!(
             task_id = config.task_id,

--- a/src/yaml_config.rs
+++ b/src/yaml_config.rs
@@ -593,7 +593,9 @@ impl YamlConfig {
                 };
 
                 let cache = if let Some(c) = &yaml_step.cache {
-                    Some(StepCache { ttl: c.ttl.to_duration()? })
+                    Some(StepCache {
+                        ttl: c.ttl.to_std_duration()?,
+                    })
                 } else {
                     None
                 };

--- a/src/yaml_config.rs
+++ b/src/yaml_config.rs
@@ -15,7 +15,9 @@ use crate::config_validation::{
 };
 use crate::config_version::VersionChecker;
 use crate::load_models::LoadModel;
-use crate::scenario::{Assertion, Extractor, RequestConfig, Scenario, Step, VariableExtraction};
+use crate::scenario::{
+    Assertion, Extractor, RequestConfig, Scenario, Step, StepCache, VariableExtraction,
+};
 
 /// Errors that can occur when loading or parsing YAML configuration.
 #[derive(Error, Debug)]
@@ -276,6 +278,12 @@ impl YamlThinkTime {
     }
 }
 
+/// Session cache config on a step — reuse extracted variables for a TTL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct YamlStepCache {
+    pub ttl: YamlDuration,
+}
+
 /// Step definition in YAML.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct YamlStep {
@@ -288,6 +296,8 @@ pub struct YamlStep {
 
     #[serde(default)]
     pub assertions: Vec<YamlAssertion>,
+
+    pub cache: Option<YamlStepCache>,
 
     #[serde(rename = "thinkTime")]
     pub think_time: Option<YamlThinkTime>,
@@ -582,11 +592,18 @@ impl YamlConfig {
                     None
                 };
 
+                let cache = if let Some(c) = &yaml_step.cache {
+                    Some(StepCache { ttl: c.ttl.to_duration()? })
+                } else {
+                    None
+                };
+
                 steps.push(Step {
                     name: step_name,
                     request,
                     extractions: extractors,
                     assertions,
+                    cache,
                     think_time,
                 });
             }

--- a/tests/assertion_integration_tests.rs
+++ b/tests/assertion_integration_tests.rs
@@ -54,7 +54,9 @@ async fn test_status_code_assertion_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps.len(), 1);
@@ -97,7 +99,9 @@ async fn test_status_code_assertion_fail() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(!result.success, "Scenario should fail due to assertion");
     assert_eq!(result.steps.len(), 1);
@@ -140,7 +144,9 @@ async fn test_response_time_assertion_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -184,7 +190,9 @@ async fn test_response_time_assertion_fail() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(!result.success, "Scenario should fail due to slow response");
     assert_eq!(result.steps[0].assertions_passed, 0);
@@ -233,7 +241,9 @@ async fn test_json_path_assertion_existence() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -279,7 +289,9 @@ async fn test_json_path_assertion_value_match() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -325,7 +337,9 @@ async fn test_json_path_assertion_value_mismatch() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(
         !result.success,
@@ -371,7 +385,9 @@ async fn test_body_contains_assertion_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -414,7 +430,9 @@ async fn test_body_contains_assertion_fail() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(!result.success, "Scenario should fail");
     assert_eq!(result.steps[0].assertions_passed, 0);
@@ -459,7 +477,9 @@ async fn test_body_matches_regex_assertion() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -499,7 +519,9 @@ async fn test_header_exists_assertion_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -540,7 +562,9 @@ async fn test_header_exists_assertion_fail() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(!result.success, "Scenario should fail");
     assert_eq!(result.steps[0].assertions_passed, 0);
@@ -594,7 +618,9 @@ async fn test_multiple_assertions_all_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 5);
@@ -643,7 +669,9 @@ async fn test_multiple_assertions_mixed_results() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(
         !result.success,
@@ -722,7 +750,9 @@ async fn test_multi_step_assertion_stops_on_failure() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(!result.success, "Scenario should fail");
     assert_eq!(
@@ -812,7 +842,9 @@ async fn test_realistic_e_commerce_flow_with_assertions() {
     let executor = ScenarioExecutor::new(ECOM_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "E-commerce flow should succeed");
     assert_eq!(result.steps_completed, 3);

--- a/tests/assertion_integration_tests.rs
+++ b/tests/assertion_integration_tests.rs
@@ -5,7 +5,7 @@
 //! scenarios.  E-commerce specific tests require ecom.edge.baugus-lab.com
 //! and are marked #[ignore].
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{Assertion, RequestConfig, Scenario, ScenarioContext, Step};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -45,6 +45,7 @@ async fn test_status_code_assertion_pass() {
             },
             extractions: vec![],
             assertions: vec![Assertion::StatusCode(200)],
+            cache: None,
             think_time: None,
         }],
     };
@@ -53,7 +54,7 @@ async fn test_status_code_assertion_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps.len(), 1);
@@ -87,6 +88,7 @@ async fn test_status_code_assertion_fail() {
             },
             extractions: vec![],
             assertions: vec![Assertion::StatusCode(404)],
+            cache: None,
             think_time: None,
         }],
     };
@@ -95,7 +97,7 @@ async fn test_status_code_assertion_fail() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(!result.success, "Scenario should fail due to assertion");
     assert_eq!(result.steps.len(), 1);
@@ -129,6 +131,7 @@ async fn test_response_time_assertion_pass() {
             },
             extractions: vec![],
             assertions: vec![Assertion::ResponseTime(Duration::from_secs(5))],
+            cache: None,
             think_time: None,
         }],
     };
@@ -137,7 +140,7 @@ async fn test_response_time_assertion_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -172,6 +175,7 @@ async fn test_response_time_assertion_fail() {
             },
             extractions: vec![],
             assertions: vec![Assertion::ResponseTime(Duration::from_millis(1))],
+            cache: None,
             think_time: None,
         }],
     };
@@ -180,7 +184,7 @@ async fn test_response_time_assertion_fail() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(!result.success, "Scenario should fail due to slow response");
     assert_eq!(result.steps[0].assertions_passed, 0);
@@ -220,6 +224,7 @@ async fn test_json_path_assertion_existence() {
                 path: "$.slideshow".to_string(),
                 expected: None, // Just check it exists
             }],
+            cache: None,
             think_time: None,
         }],
     };
@@ -228,7 +233,7 @@ async fn test_json_path_assertion_existence() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -265,6 +270,7 @@ async fn test_json_path_assertion_value_match() {
                 path: "$.slideshow.title".to_string(),
                 expected: Some("Sample Slide Show".to_string()),
             }],
+            cache: None,
             think_time: None,
         }],
     };
@@ -273,7 +279,7 @@ async fn test_json_path_assertion_value_match() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -310,6 +316,7 @@ async fn test_json_path_assertion_value_mismatch() {
                 path: "$.slideshow.title".to_string(),
                 expected: Some("Wrong Title".to_string()), // Should be "Sample Slide Show"
             }],
+            cache: None,
             think_time: None,
         }],
     };
@@ -318,7 +325,7 @@ async fn test_json_path_assertion_value_mismatch() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(
         !result.success,
@@ -355,6 +362,7 @@ async fn test_body_contains_assertion_pass() {
             },
             extractions: vec![],
             assertions: vec![Assertion::BodyContains("slideshow".to_string())],
+            cache: None,
             think_time: None,
         }],
     };
@@ -363,7 +371,7 @@ async fn test_body_contains_assertion_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -397,6 +405,7 @@ async fn test_body_contains_assertion_fail() {
             },
             extractions: vec![],
             assertions: vec![Assertion::BodyContains("MISSING_TEXT_XYZ".to_string())],
+            cache: None,
             think_time: None,
         }],
     };
@@ -405,7 +414,7 @@ async fn test_body_contains_assertion_fail() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(!result.success, "Scenario should fail");
     assert_eq!(result.steps[0].assertions_passed, 0);
@@ -441,6 +450,7 @@ async fn test_body_matches_regex_assertion() {
             assertions: vec![Assertion::BodyMatches(
                 r#""slideshow"\s*:\s*\{"#.to_string(),
             )],
+            cache: None,
             think_time: None,
         }],
     };
@@ -449,7 +459,7 @@ async fn test_body_matches_regex_assertion() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -480,6 +490,7 @@ async fn test_header_exists_assertion_pass() {
             },
             extractions: vec![],
             assertions: vec![Assertion::HeaderExists("content-type".to_string())],
+            cache: None,
             think_time: None,
         }],
     };
@@ -488,7 +499,7 @@ async fn test_header_exists_assertion_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 1);
@@ -520,6 +531,7 @@ async fn test_header_exists_assertion_fail() {
             },
             extractions: vec![],
             assertions: vec![Assertion::HeaderExists("x-missing-header".to_string())],
+            cache: None,
             think_time: None,
         }],
     };
@@ -528,7 +540,7 @@ async fn test_header_exists_assertion_fail() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(!result.success, "Scenario should fail");
     assert_eq!(result.steps[0].assertions_passed, 0);
@@ -573,6 +585,7 @@ async fn test_multiple_assertions_all_pass() {
                 Assertion::BodyContains("headers".to_string()),
                 Assertion::HeaderExists("content-type".to_string()),
             ],
+            cache: None,
             think_time: None,
         }],
     };
@@ -581,7 +594,7 @@ async fn test_multiple_assertions_all_pass() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "Scenario should succeed");
     assert_eq!(result.steps[0].assertions_passed, 5);
@@ -621,6 +634,7 @@ async fn test_multiple_assertions_mixed_results() {
                 Assertion::StatusCode(404),                     // FAIL
                 Assertion::BodyContains("MISSING".to_string()), // FAIL
             ],
+            cache: None,
             think_time: None,
         }],
     };
@@ -629,7 +643,7 @@ async fn test_multiple_assertions_mixed_results() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(
         !result.success,
@@ -672,6 +686,7 @@ async fn test_multi_step_assertion_stops_on_failure() {
                 },
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
+                cache: None,
                 think_time: None,
             },
             Step {
@@ -684,6 +699,7 @@ async fn test_multi_step_assertion_stops_on_failure() {
                 },
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(404)], // Will fail
+                cache: None,
                 think_time: None,
             },
             Step {
@@ -696,6 +712,7 @@ async fn test_multi_step_assertion_stops_on_failure() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
         ],
@@ -705,7 +722,7 @@ async fn test_multi_step_assertion_stops_on_failure() {
     let executor = ScenarioExecutor::new(server.uri(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(!result.success, "Scenario should fail");
     assert_eq!(
@@ -746,6 +763,7 @@ async fn test_realistic_e_commerce_flow_with_assertions() {
                     Assertion::StatusCode(200),
                     Assertion::ResponseTime(Duration::from_secs(2)),
                 ],
+                cache: None,
                 think_time: None,
             },
             Step {
@@ -764,6 +782,7 @@ async fn test_realistic_e_commerce_flow_with_assertions() {
                     Assertion::BodyContains("name".to_string()),
                     Assertion::HeaderExists("content-type".to_string()),
                 ],
+                cache: None,
                 think_time: None,
             },
             Step {
@@ -783,6 +802,7 @@ async fn test_realistic_e_commerce_flow_with_assertions() {
                     },
                     Assertion::BodyMatches(r#""status"\s*:\s*"ok""#.to_string()),
                 ],
+                cache: None,
                 think_time: None,
             },
         ],
@@ -792,7 +812,7 @@ async fn test_realistic_e_commerce_flow_with_assertions() {
     let executor = ScenarioExecutor::new(ECOM_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
     assert!(result.success, "E-commerce flow should succeed");
     assert_eq!(result.steps_completed, 3);

--- a/tests/cookie_session_tests.rs
+++ b/tests/cookie_session_tests.rs
@@ -3,7 +3,7 @@
 //! These tests validate that cookies are automatically handled across
 //! requests within a scenario, enabling session-based authentication.
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{
     Extractor, RequestConfig, Scenario, ScenarioContext, Step, ThinkTime, VariableExtraction,
 };
@@ -50,7 +50,8 @@ async fn test_cookies_persist_across_steps() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
             },
             Step {
                 name: "Access Protected Resource (uses cookies)".to_string(),
@@ -62,7 +63,8 @@ async fn test_cookies_persist_across_steps() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -71,7 +73,9 @@ async fn test_cookies_persist_across_steps() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // If cookies work, both steps should succeed
     // Step 1: Login sets session cookie
@@ -132,7 +136,8 @@ async fn test_auth_flow_with_token_and_cookies() {
                     },
                 ],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Access Profile with Token".to_string(),
@@ -152,7 +157,8 @@ async fn test_auth_flow_with_token_and_cookies() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -161,7 +167,9 @@ async fn test_auth_flow_with_token_and_cookies() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     println!("\nAuth Flow Test:");
     println!(
@@ -220,6 +228,7 @@ async fn test_cookie_isolation_between_clients() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -235,8 +244,12 @@ async fn test_cookie_isolation_between_clients() {
     let mut context2 = ScenarioContext::new();
 
     // Execute scenarios with different clients
-    let result1 = executor1.execute(&scenario, &mut context1).await;
-    let result2 = executor2.execute(&scenario, &mut context2).await;
+    let result1 = executor1
+        .execute(&scenario, &mut context1, &mut SessionStore::new())
+        .await;
+    let result2 = executor2
+        .execute(&scenario, &mut context2, &mut SessionStore::new())
+        .await;
 
     println!("\nCookie Isolation Test:");
     println!("  Client 1: {}", if result1.success { "✓" } else { "✗" });
@@ -270,7 +283,8 @@ async fn test_shopping_flow_with_session() {
                     extractor: Extractor::JsonPath("$.products[0].id".to_string()),
                 }],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Register and Login".to_string(),
@@ -296,7 +310,8 @@ async fn test_shopping_flow_with_session() {
                     extractor: Extractor::JsonPath("$.token".to_string()),
                 }],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Add to Cart (with auth)".to_string(),
@@ -319,7 +334,8 @@ async fn test_shopping_flow_with_session() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "View Cart (session maintained)".to_string(),
@@ -335,7 +351,8 @@ async fn test_shopping_flow_with_session() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -344,7 +361,9 @@ async fn test_shopping_flow_with_session() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     println!("\nShopping Flow with Session:");
     println!("  Success: {}", result.success);
@@ -392,6 +411,7 @@ async fn test_client_without_cookies_fails_session() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -412,10 +432,10 @@ async fn test_client_without_cookies_fails_session() {
     let mut context_with_cookies = ScenarioContext::new();
 
     let result_no_cookies = executor_no_cookies
-        .execute(&scenario, &mut context_no_cookies)
+        .execute(&scenario, &mut context_no_cookies, &mut SessionStore::new())
         .await;
     let result_with_cookies = executor_with_cookies
-        .execute(&scenario, &mut context_with_cookies)
+        .execute(&scenario, &mut context_with_cookies, &mut SessionStore::new())
         .await;
 
     println!("\nCookie Enabled Comparison:");

--- a/tests/cookie_session_tests.rs
+++ b/tests/cookie_session_tests.rs
@@ -51,7 +51,7 @@ async fn test_cookies_persist_across_steps() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
             },
             Step {
                 name: "Access Protected Resource (uses cookies)".to_string(),
@@ -64,7 +64,7 @@ async fn test_cookies_persist_across_steps() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };
@@ -137,7 +137,7 @@ async fn test_auth_flow_with_token_and_cookies() {
                 ],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Access Profile with Token".to_string(),
@@ -158,7 +158,7 @@ async fn test_auth_flow_with_token_and_cookies() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };
@@ -284,7 +284,7 @@ async fn test_shopping_flow_with_session() {
                 }],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Register and Login".to_string(),
@@ -311,7 +311,7 @@ async fn test_shopping_flow_with_session() {
                 }],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Add to Cart (with auth)".to_string(),
@@ -335,7 +335,7 @@ async fn test_shopping_flow_with_session() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "View Cart (session maintained)".to_string(),
@@ -352,7 +352,7 @@ async fn test_shopping_flow_with_session() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };
@@ -435,7 +435,11 @@ async fn test_client_without_cookies_fails_session() {
         .execute(&scenario, &mut context_no_cookies, &mut SessionStore::new())
         .await;
     let result_with_cookies = executor_with_cookies
-        .execute(&scenario, &mut context_with_cookies, &mut SessionStore::new())
+        .execute(
+            &scenario,
+            &mut context_with_cookies,
+            &mut SessionStore::new(),
+        )
         .await;
 
     println!("\nCookie Enabled Comparison:");

--- a/tests/csv_data_driven_tests.rs
+++ b/tests/csv_data_driven_tests.rs
@@ -4,7 +4,7 @@
 //! virtual users, and used for variable substitution in scenarios.
 
 use rust_loadtest::data_source::CsvDataSource;
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{Assertion, RequestConfig, Scenario, ScenarioContext, Step};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -147,6 +147,7 @@ async fn test_scenario_with_csv_data() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -160,7 +161,7 @@ async fn test_scenario_with_csv_data() {
         let row = ds.next_row().unwrap();
         context.load_data_row(&row);
 
-        let result = executor.execute(&scenario, &mut context).await;
+        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
         assert!(result.steps[0].status_code.is_some());
         println!(
@@ -191,6 +192,7 @@ async fn test_multiple_users_different_data() {
             },
             extractions: vec![],
             assertions: vec![Assertion::StatusCode(200)],
+            cache: None,
             think_time: None,
         }],
     };
@@ -209,7 +211,7 @@ async fn test_multiple_users_different_data() {
 
         context.load_data_row(&row);
 
-        let result = executor.execute(&scenario, &mut context).await;
+        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
         assert!(result.success, "Virtual user {} should succeed", i + 1);
         println!("  Virtual user {} used data: {}", i + 1, username);
@@ -246,6 +248,7 @@ dave,dave012,dave@company.com,manager"#;
                 },
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
+                cache: None,
                 think_time: None,
             },
             Step {
@@ -258,6 +261,7 @@ dave,dave012,dave@company.com,manager"#;
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
         ],
@@ -275,7 +279,7 @@ dave,dave012,dave@company.com,manager"#;
 
         context.load_data_row(&row);
 
-        let result = executor.execute(&scenario, &mut context).await;
+        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
         assert!(result.success, "User {} should succeed", username);
         println!("  VU {} as {} (role: {})", i + 1, username, role);

--- a/tests/csv_data_driven_tests.rs
+++ b/tests/csv_data_driven_tests.rs
@@ -161,7 +161,9 @@ async fn test_scenario_with_csv_data() {
         let row = ds.next_row().unwrap();
         context.load_data_row(&row);
 
-        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+        let result = executor
+            .execute(&scenario, &mut context, &mut SessionStore::new())
+            .await;
 
         assert!(result.steps[0].status_code.is_some());
         println!(
@@ -211,7 +213,9 @@ async fn test_multiple_users_different_data() {
 
         context.load_data_row(&row);
 
-        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+        let result = executor
+            .execute(&scenario, &mut context, &mut SessionStore::new())
+            .await;
 
         assert!(result.success, "Virtual user {} should succeed", i + 1);
         println!("  Virtual user {} used data: {}", i + 1, username);
@@ -279,7 +283,9 @@ dave,dave012,dave@company.com,manager"#;
 
         context.load_data_row(&row);
 
-        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+        let result = executor
+            .execute(&scenario, &mut context, &mut SessionStore::new())
+            .await;
 
         assert!(result.success, "User {} should succeed", username);
         println!("  VU {} as {} (role: {})", i + 1, username, role);

--- a/tests/http_methods_tests.rs
+++ b/tests/http_methods_tests.rs
@@ -311,7 +311,7 @@ async fn test_mixed_methods_scenario() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "POST status".to_string(),
@@ -328,7 +328,7 @@ async fn test_mixed_methods_scenario() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "PUT status".to_string(),
@@ -345,7 +345,7 @@ async fn test_mixed_methods_scenario() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "HEAD health".to_string(),
@@ -358,7 +358,7 @@ async fn test_mixed_methods_scenario() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };
@@ -418,7 +418,7 @@ async fn test_case_insensitive_methods() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             }],
         };
 
@@ -427,8 +427,8 @@ async fn test_case_insensitive_methods() {
         let mut context = ScenarioContext::new();
 
         let result = executor
-        .execute(&scenario, &mut context, &mut SessionStore::new())
-        .await;
+            .execute(&scenario, &mut context, &mut SessionStore::new())
+            .await;
 
         assert!(result.success, "{} should work (case-insensitive)", method);
     }
@@ -454,7 +454,7 @@ async fn test_rest_crud_flow() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "2. POST - Create".to_string(),
@@ -471,7 +471,7 @@ async fn test_rest_crud_flow() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "3. PUT - Update full".to_string(),
@@ -490,7 +490,7 @@ async fn test_rest_crud_flow() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "4. PATCH - Partial update".to_string(),
@@ -507,7 +507,7 @@ async fn test_rest_crud_flow() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "5. HEAD - Check existence".to_string(),
@@ -520,7 +520,7 @@ async fn test_rest_crud_flow() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "6. DELETE - Remove".to_string(),
@@ -533,7 +533,7 @@ async fn test_rest_crud_flow() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };

--- a/tests/http_methods_tests.rs
+++ b/tests/http_methods_tests.rs
@@ -3,7 +3,7 @@
 //! These tests validate that GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS
 //! methods work correctly in both single requests and multi-step scenarios.
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{RequestConfig, Scenario, ScenarioContext, Step};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -33,6 +33,7 @@ async fn test_get_request() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -41,7 +42,9 @@ async fn test_get_request() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(
         result.steps[0].status_code.is_some(),
@@ -73,6 +76,7 @@ async fn test_post_request() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -81,7 +85,9 @@ async fn test_post_request() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(
         result.steps[0].status_code.is_some(),
@@ -113,6 +119,7 @@ async fn test_put_request() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -121,7 +128,9 @@ async fn test_put_request() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // PUT may return 2xx/3xx or 4xx depending on endpoint implementation
     assert!(result.steps[0].status_code.is_some());
@@ -151,6 +160,7 @@ async fn test_patch_request() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -159,7 +169,9 @@ async fn test_patch_request() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // PATCH may return 2xx/3xx or 4xx depending on endpoint implementation
     assert!(result.steps[0].status_code.is_some());
@@ -185,6 +197,7 @@ async fn test_delete_request() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -193,7 +206,9 @@ async fn test_delete_request() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // DELETE may return 2xx/3xx or 4xx depending on endpoint implementation
     assert!(result.steps[0].status_code.is_some());
@@ -219,6 +234,7 @@ async fn test_head_request() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -227,7 +243,9 @@ async fn test_head_request() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // HEAD should return same status as GET but no body
     assert!(result.success, "HEAD request should succeed");
@@ -254,6 +272,7 @@ async fn test_options_request() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -262,7 +281,9 @@ async fn test_options_request() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // OPTIONS typically returns 200 or 204 with Allow header
     assert!(result.steps[0].status_code.is_some());
@@ -289,7 +310,8 @@ async fn test_mixed_methods_scenario() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "POST status".to_string(),
@@ -305,7 +327,8 @@ async fn test_mixed_methods_scenario() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "PUT status".to_string(),
@@ -321,7 +344,8 @@ async fn test_mixed_methods_scenario() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "HEAD health".to_string(),
@@ -333,7 +357,8 @@ async fn test_mixed_methods_scenario() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -342,7 +367,9 @@ async fn test_mixed_methods_scenario() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // All steps should execute (some may fail depending on API implementation)
     assert!(result.steps.len() >= 2, "Should execute multiple steps");
@@ -390,7 +417,8 @@ async fn test_case_insensitive_methods() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             }],
         };
 
@@ -398,7 +426,9 @@ async fn test_case_insensitive_methods() {
         let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
         let mut context = ScenarioContext::new();
 
-        let result = executor.execute(&scenario, &mut context).await;
+        let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
         assert!(result.success, "{} should work (case-insensitive)", method);
     }
@@ -423,7 +453,8 @@ async fn test_rest_crud_flow() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "2. POST - Create".to_string(),
@@ -439,7 +470,8 @@ async fn test_rest_crud_flow() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "3. PUT - Update full".to_string(),
@@ -457,7 +489,8 @@ async fn test_rest_crud_flow() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "4. PATCH - Partial update".to_string(),
@@ -473,7 +506,8 @@ async fn test_rest_crud_flow() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "5. HEAD - Check existence".to_string(),
@@ -485,7 +519,8 @@ async fn test_rest_crud_flow() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "6. DELETE - Remove".to_string(),
@@ -497,7 +532,8 @@ async fn test_rest_crud_flow() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -506,7 +542,9 @@ async fn test_rest_crud_flow() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     println!("✅ REST CRUD flow executed");
     println!("   Total steps: {}", result.steps.len());
@@ -546,6 +584,7 @@ async fn test_options_cors_preflight() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -554,7 +593,9 @@ async fn test_options_cors_preflight() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.steps[0].status_code.is_some());
 

--- a/tests/per_scenario_throughput_tests.rs
+++ b/tests/per_scenario_throughput_tests.rs
@@ -3,7 +3,7 @@
 //! These tests validate that throughput (requests per second) is tracked
 //! separately for each scenario type, enabling performance comparison.
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{RequestConfig, Scenario, ScenarioContext, Step};
 use rust_loadtest::throughput::{format_throughput_table, ThroughputTracker};
 use std::collections::HashMap;
@@ -169,6 +169,7 @@ async fn test_scenario_throughput_tracking() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -179,7 +180,7 @@ async fn test_scenario_throughput_tracking() {
         let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
         let mut context = ScenarioContext::new();
 
-        let result = executor.execute(&scenario, &mut context).await;
+        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
         assert!(result.success);
 
         // Record throughput
@@ -211,6 +212,7 @@ async fn test_multiple_scenarios_different_throughput() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -229,6 +231,7 @@ async fn test_multiple_scenarios_different_throughput() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
             Step {
@@ -241,6 +244,7 @@ async fn test_multiple_scenarios_different_throughput() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
         ],
@@ -252,7 +256,7 @@ async fn test_multiple_scenarios_different_throughput() {
         let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
         let mut context = ScenarioContext::new();
 
-        let result = executor.execute(&fast_scenario, &mut context).await;
+        let result = executor.execute(&fast_scenario, &mut context, &mut SessionStore::new()).await;
         tracker.record(
             &fast_scenario.name,
             Duration::from_millis(result.total_time_ms),
@@ -265,7 +269,7 @@ async fn test_multiple_scenarios_different_throughput() {
         let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
         let mut context = ScenarioContext::new();
 
-        let result = executor.execute(&slow_scenario, &mut context).await;
+        let result = executor.execute(&slow_scenario, &mut context, &mut SessionStore::new()).await;
         tracker.record(
             &slow_scenario.name,
             Duration::from_millis(result.total_time_ms),

--- a/tests/per_scenario_throughput_tests.rs
+++ b/tests/per_scenario_throughput_tests.rs
@@ -180,7 +180,9 @@ async fn test_scenario_throughput_tracking() {
         let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
         let mut context = ScenarioContext::new();
 
-        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+        let result = executor
+            .execute(&scenario, &mut context, &mut SessionStore::new())
+            .await;
         assert!(result.success);
 
         // Record throughput
@@ -256,7 +258,9 @@ async fn test_multiple_scenarios_different_throughput() {
         let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
         let mut context = ScenarioContext::new();
 
-        let result = executor.execute(&fast_scenario, &mut context, &mut SessionStore::new()).await;
+        let result = executor
+            .execute(&fast_scenario, &mut context, &mut SessionStore::new())
+            .await;
         tracker.record(
             &fast_scenario.name,
             Duration::from_millis(result.total_time_ms),
@@ -269,7 +273,9 @@ async fn test_multiple_scenarios_different_throughput() {
         let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
         let mut context = ScenarioContext::new();
 
-        let result = executor.execute(&slow_scenario, &mut context, &mut SessionStore::new()).await;
+        let result = executor
+            .execute(&slow_scenario, &mut context, &mut SessionStore::new())
+            .await;
         tracker.record(
             &slow_scenario.name,
             Duration::from_millis(result.total_time_ms),

--- a/tests/percentile_tracking_tests.rs
+++ b/tests/percentile_tracking_tests.rs
@@ -259,7 +259,9 @@ async fn test_scenario_percentile_tracking() {
     // Execute scenario multiple times
     for _ in 0..5 {
         let mut context = ScenarioContext::new();
-        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
+        let result = executor
+            .execute(&scenario, &mut context, &mut SessionStore::new())
+            .await;
 
         assert!(result.success);
 

--- a/tests/percentile_tracking_tests.rs
+++ b/tests/percentile_tracking_tests.rs
@@ -3,7 +3,7 @@
 //! These tests validate that percentile calculations are accurate and that
 //! latencies are properly tracked across requests, scenarios, and steps.
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::percentiles::{
     MultiLabelPercentileTracker, PercentileTracker, GLOBAL_SCENARIO_PERCENTILES,
     GLOBAL_STEP_PERCENTILES,
@@ -234,6 +234,7 @@ async fn test_scenario_percentile_tracking() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
             Step {
@@ -246,6 +247,7 @@ async fn test_scenario_percentile_tracking() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
         ],
@@ -257,7 +259,7 @@ async fn test_scenario_percentile_tracking() {
     // Execute scenario multiple times
     for _ in 0..5 {
         let mut context = ScenarioContext::new();
-        let result = executor.execute(&scenario, &mut context).await;
+        let result = executor.execute(&scenario, &mut context, &mut SessionStore::new()).await;
 
         assert!(result.success);
 

--- a/tests/scenario_integration_tests.rs
+++ b/tests/scenario_integration_tests.rs
@@ -74,7 +74,7 @@ async fn test_product_browsing_scenario() {
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
             },
             Step {
                 name: "Get Item Details".to_string(),
@@ -87,7 +87,7 @@ async fn test_product_browsing_scenario() {
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };
@@ -181,7 +181,7 @@ async fn test_multi_step_with_delays() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
             },
             Step {
                 name: "Step 2".to_string(),
@@ -194,7 +194,7 @@ async fn test_multi_step_with_delays() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
             },
             Step {
                 name: "Step 3".to_string(),
@@ -207,7 +207,7 @@ async fn test_multi_step_with_delays() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };
@@ -250,7 +250,7 @@ async fn test_scenario_failure_handling() {
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "Invalid Request".to_string(),
@@ -263,7 +263,7 @@ async fn test_scenario_failure_handling() {
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "Should Not Execute".to_string(),
@@ -276,7 +276,7 @@ async fn test_scenario_failure_handling() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };

--- a/tests/scenario_integration_tests.rs
+++ b/tests/scenario_integration_tests.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: cargo test --test scenario_integration_tests
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{
     Assertion, RequestConfig, Scenario, ScenarioContext, Step, ThinkTime,
 };
@@ -39,6 +39,7 @@ async fn test_health_check_scenario() {
             },
             extractions: vec![],
             assertions: vec![Assertion::StatusCode(200)],
+            cache: None,
             think_time: None,
         }],
     };
@@ -47,7 +48,9 @@ async fn test_health_check_scenario() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Health check scenario should succeed");
     assert_eq!(result.steps.len(), 1);
@@ -70,7 +73,8 @@ async fn test_product_browsing_scenario() {
                 },
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
             },
             Step {
                 name: "Get Item Details".to_string(),
@@ -82,7 +86,8 @@ async fn test_product_browsing_scenario() {
                 },
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -91,7 +96,9 @@ async fn test_product_browsing_scenario() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Product browsing scenario should succeed");
     assert_eq!(result.steps_completed, 2);
@@ -124,6 +131,7 @@ async fn test_variable_substitution() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -131,7 +139,9 @@ async fn test_variable_substitution() {
     let client = create_test_client();
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // The request should have been made to /products/prod-123
     // If variable substitution works, we'll get a response
@@ -170,7 +180,8 @@ async fn test_multi_step_with_delays() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
             },
             Step {
                 name: "Step 2".to_string(),
@@ -182,7 +193,8 @@ async fn test_multi_step_with_delays() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
             },
             Step {
                 name: "Step 3".to_string(),
@@ -194,7 +206,8 @@ async fn test_multi_step_with_delays() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -204,7 +217,9 @@ async fn test_multi_step_with_delays() {
     let mut context = ScenarioContext::new();
 
     let start = std::time::Instant::now();
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
     let duration = start.elapsed();
 
     assert!(result.success, "Multi-step scenario should succeed");
@@ -234,7 +249,8 @@ async fn test_scenario_failure_handling() {
                 },
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "Invalid Request".to_string(),
@@ -246,7 +262,8 @@ async fn test_scenario_failure_handling() {
                 },
                 extractions: vec![],
                 assertions: vec![Assertion::StatusCode(200)],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "Should Not Execute".to_string(),
@@ -258,7 +275,8 @@ async fn test_scenario_failure_handling() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -267,7 +285,9 @@ async fn test_scenario_failure_handling() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // Scenario should fail on step 2
     assert!(!result.success, "Scenario should fail");
@@ -308,6 +328,7 @@ async fn test_timestamp_variable() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -316,7 +337,9 @@ async fn test_timestamp_variable() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // Timestamp substitution should work, request should succeed
     assert!(result.success, "Scenario with timestamp should succeed");
@@ -349,6 +372,7 @@ async fn test_post_request_with_json_body() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -357,7 +381,9 @@ async fn test_post_request_with_json_body() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // POST should work (200 OK from httpbin)
     assert!(
@@ -383,6 +409,7 @@ async fn test_scenario_context_isolation() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -397,8 +424,12 @@ async fn test_scenario_context_isolation() {
     let mut context2 = ScenarioContext::new();
     context2.set_variable("test".to_string(), "value2".to_string());
 
-    let result1 = executor.execute(&scenario, &mut context1).await;
-    let result2 = executor.execute(&scenario, &mut context2).await;
+    let result1 = executor
+        .execute(&scenario, &mut context1, &mut SessionStore::new())
+        .await;
+    let result2 = executor
+        .execute(&scenario, &mut context2, &mut SessionStore::new())
+        .await;
 
     // Both should succeed
     assert!(result1.success);

--- a/tests/scenario_worker_tests.rs
+++ b/tests/scenario_worker_tests.rs
@@ -25,6 +25,7 @@ async fn test_scenario_worker_respects_duration() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -72,6 +73,7 @@ async fn test_scenario_worker_constant_load() {
             },
             extractions: vec![],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -115,7 +117,8 @@ async fn test_scenario_worker_with_think_time() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Step 2".to_string(),
@@ -127,7 +130,8 @@ async fn test_scenario_worker_with_think_time() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };

--- a/tests/scenario_worker_tests.rs
+++ b/tests/scenario_worker_tests.rs
@@ -118,7 +118,7 @@ async fn test_scenario_worker_with_think_time() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Step 2".to_string(),
@@ -131,7 +131,7 @@ async fn test_scenario_worker_with_think_time() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };

--- a/tests/think_time_tests.rs
+++ b/tests/think_time_tests.rs
@@ -169,8 +169,8 @@ async fn test_random_think_time() {
         let mut context = ScenarioContext::new();
         let start = Instant::now();
         let result = executor
-        .execute(&scenario, &mut context, &mut SessionStore::new())
-        .await;
+            .execute(&scenario, &mut context, &mut SessionStore::new())
+            .await;
         let total_duration = start.elapsed();
 
         assert!(result.success);

--- a/tests/think_time_tests.rs
+++ b/tests/think_time_tests.rs
@@ -5,7 +5,7 @@
 //! - Support both fixed and random delays
 //! - Do NOT count towards request latency metrics
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{RequestConfig, Scenario, ScenarioContext, Step, ThinkTime};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -53,6 +53,7 @@ async fn test_fixed_think_time() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
@@ -65,6 +66,7 @@ async fn test_fixed_think_time() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
         ],
@@ -75,7 +77,9 @@ async fn test_fixed_think_time() {
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
     let total_duration = start.elapsed();
 
     assert!(result.success, "Scenario should succeed");
@@ -133,6 +137,7 @@ async fn test_random_think_time() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: Some(ThinkTime::Random {
                     min: Duration::from_millis(200),
                     max: Duration::from_millis(800),
@@ -148,6 +153,7 @@ async fn test_random_think_time() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
         ],
@@ -162,7 +168,9 @@ async fn test_random_think_time() {
     for _ in 0..5 {
         let mut context = ScenarioContext::new();
         let start = Instant::now();
-        let result = executor.execute(&scenario, &mut context).await;
+        let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
         let total_duration = start.elapsed();
 
         assert!(result.success);
@@ -209,6 +217,7 @@ async fn test_multiple_think_times() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
             },
             Step {
@@ -221,6 +230,7 @@ async fn test_multiple_think_times() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_millis(200))),
             },
             Step {
@@ -233,6 +243,7 @@ async fn test_multiple_think_times() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: Some(ThinkTime::Fixed(Duration::from_millis(300))),
             },
         ],
@@ -243,7 +254,9 @@ async fn test_multiple_think_times() {
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
     let total_duration = start.elapsed();
 
     assert!(result.success);
@@ -295,6 +308,7 @@ async fn test_no_think_time() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
             Step {
@@ -307,6 +321,7 @@ async fn test_no_think_time() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: None,
             },
         ],
@@ -317,7 +332,9 @@ async fn test_no_think_time() {
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
     let total_duration = start.elapsed();
 
     assert!(result.success);
@@ -354,6 +371,7 @@ async fn test_realistic_user_behavior() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: Some(ThinkTime::Random {
                     min: Duration::from_secs(1),
                     max: Duration::from_secs(3),
@@ -369,6 +387,7 @@ async fn test_realistic_user_behavior() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: Some(ThinkTime::Random {
                     min: Duration::from_secs(2),
                     max: Duration::from_secs(5),
@@ -384,6 +403,7 @@ async fn test_realistic_user_behavior() {
                 },
                 extractions: vec![],
                 assertions: vec![],
+                cache: None,
                 think_time: Some(ThinkTime::Random {
                     min: Duration::from_secs(3),
                     max: Duration::from_secs(10),
@@ -397,7 +417,9 @@ async fn test_realistic_user_behavior() {
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
     let total_duration = start.elapsed();
 
     assert!(result.success);

--- a/tests/variable_extraction_tests.rs
+++ b/tests/variable_extraction_tests.rs
@@ -3,7 +3,7 @@
 //! These tests validate JSONPath, Regex, Header, and Cookie extraction
 //! from HTTP responses against httpbin.org.
 
-use rust_loadtest::executor::ScenarioExecutor;
+use rust_loadtest::executor::{ScenarioExecutor, SessionStore};
 use rust_loadtest::scenario::{
     Extractor, RequestConfig, Scenario, ScenarioContext, Step, ThinkTime, VariableExtraction,
 };
@@ -44,6 +44,7 @@ async fn test_jsonpath_extraction_from_products() {
                 },
             ],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -52,7 +53,9 @@ async fn test_jsonpath_extraction_from_products() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Scenario should succeed");
 
@@ -90,7 +93,8 @@ async fn test_extraction_and_reuse_in_next_step() {
                     extractor: Extractor::JsonPath("$.origin".to_string()),
                 }],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
             },
             Step {
                 name: "Use Extracted Value".to_string(),
@@ -102,7 +106,8 @@ async fn test_extraction_and_reuse_in_next_step() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -111,7 +116,9 @@ async fn test_extraction_and_reuse_in_next_step() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Both steps should succeed");
     assert_eq!(result.steps_completed, 2, "Should complete both steps");
@@ -148,6 +155,7 @@ async fn test_header_extraction() {
                 extractor: Extractor::Header("content-type".to_string()),
             }],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -156,7 +164,9 @@ async fn test_header_extraction() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Should succeed");
 
@@ -202,6 +212,7 @@ async fn test_multiple_extractions_in_single_step() {
                 },
             ],
             assertions: vec![],
+            cache: None,
             think_time: None,
         }],
     };
@@ -210,7 +221,9 @@ async fn test_multiple_extractions_in_single_step() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     assert!(result.success, "Should succeed");
 
@@ -254,7 +267,8 @@ async fn test_shopping_flow_with_extraction() {
                     extractor: Extractor::JsonPath("$.slideshow.author".to_string()),
                 }],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Post Data with Extracted Value".to_string(),
@@ -279,7 +293,8 @@ async fn test_shopping_flow_with_extraction() {
                     extractor: Extractor::JsonPath("$.url".to_string()),
                 }],
                 assertions: vec![],
-                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                cache: None,
+            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Final GET".to_string(),
@@ -294,7 +309,8 @@ async fn test_shopping_flow_with_extraction() {
                     extractor: Extractor::JsonPath("$.origin".to_string()),
                 }],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -303,7 +319,9 @@ async fn test_shopping_flow_with_extraction() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // All steps should succeed
     assert!(result.success, "Multi-step flow should succeed");
@@ -346,7 +364,8 @@ async fn test_extraction_failure_doesnt_stop_scenario() {
                     },
                 ],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
             Step {
                 name: "Next Step".to_string(),
@@ -358,7 +377,8 @@ async fn test_extraction_failure_doesnt_stop_scenario() {
                 },
                 extractions: vec![],
                 assertions: vec![],
-                think_time: None,
+                cache: None,
+            think_time: None,
             },
         ],
     };
@@ -367,7 +387,9 @@ async fn test_extraction_failure_doesnt_stop_scenario() {
     let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
     let mut context = ScenarioContext::new();
 
-    let result = executor.execute(&scenario, &mut context).await;
+    let result = executor
+        .execute(&scenario, &mut context, &mut SessionStore::new())
+        .await;
 
     // Scenario should still succeed
     assert!(

--- a/tests/variable_extraction_tests.rs
+++ b/tests/variable_extraction_tests.rs
@@ -94,7 +94,7 @@ async fn test_extraction_and_reuse_in_next_step() {
                 }],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(100))),
             },
             Step {
                 name: "Use Extracted Value".to_string(),
@@ -107,7 +107,7 @@ async fn test_extraction_and_reuse_in_next_step() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };
@@ -268,7 +268,7 @@ async fn test_shopping_flow_with_extraction() {
                 }],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Post Data with Extracted Value".to_string(),
@@ -294,7 +294,7 @@ async fn test_shopping_flow_with_extraction() {
                 }],
                 assertions: vec![],
                 cache: None,
-            think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
+                think_time: Some(ThinkTime::Fixed(Duration::from_millis(500))),
             },
             Step {
                 name: "Final GET".to_string(),
@@ -310,7 +310,7 @@ async fn test_shopping_flow_with_extraction() {
                 }],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };
@@ -365,7 +365,7 @@ async fn test_extraction_failure_doesnt_stop_scenario() {
                 ],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
             Step {
                 name: "Next Step".to_string(),
@@ -378,7 +378,7 @@ async fn test_extraction_failure_doesnt_stop_scenario() {
                 extractions: vec![],
                 assertions: vec![],
                 cache: None,
-            think_time: None,
+                think_time: None,
             },
         ],
     };


### PR DESCRIPTION
## Summary

This PR consolidates all Phase 4 and Phase 5 work since the last merge to main.

### Phase 4 — Standalone mode, health API, standby

- **#82 — Remove Raft consensus layer**: Deleted ~3,400 lines of Raft/gRPC/Consul coordination. Each node is fully autonomous — config pushed via `POST /config`, no leader election or quorum.
- **#84 — Enrich `GET /health`**: Rich JSON (RPS, error rate, workers, memory, CPU, time remaining, test YAML, percent complete).
- **#85 — Test lifecycle state tracking**: `node_state: "running" | "standby" | "idle"`, `test_started_at_unix`, `test_duration_secs`, `test_percent_complete`.
- **#86 — Standby config**: After duration expires, nodes transition to `"standby"`. Optional `standby:` YAML block controls standby workers and RPS.
- **Bug fix — YAML duration ignored**: `POST /config` YAML duration (e.g. 72h) now wins over startup `TEST_DURATION` env var. Process stays alive in standby until SIGTERM.
- **CI — Docker image pruning**: `prune-old-dev-images` deletes `dev-<sha>` tags older than 24h after each push.
- **Docs**: README and Docker Hub overview updated for standalone mode.

### Phase 5 — Multi-host steps, per-step metrics, session token cache

- **Multi-host step URL override**: A step's `path` can now be a full URL (`http://host-b/endpoint`) to hit a different host than `baseUrl`. Fully backwards-compatible — relative paths unchanged.
- **POST /config → scenario worker dispatch**: Fixed root bug where `POST /config` always spawned the legacy single-URL worker, ignoring YAML scenarios. Now detects scenarios and spawns `run_scenario_worker`.
- **#90 — Per-step Prometheus metrics**: `scenario_step_duration_seconds`, `scenario_steps_total`, `scenario_assertions_total`, `scenario_step_status_codes_total` all labelled with `scenario` and `step`. Fixed pre-existing bug where scenario label was hardcoded to `"scenario"`.
- **RPS accuracy**: Each step execution now increments `REQUEST_TOTAL`, so health endpoint RPS reflects all HTTP requests made (not just scenario completions).
- **Per-worker session token cache**: Steps with `cache: { ttl: "1h" }` store extracted variables (e.g. JWT) in a per-worker `SessionStore`. Subsequent scenario iterations skip the HTTP request and inject the cached values directly until TTL expires — simulating an app that re-authenticates only on token expiry.
- **Grafana dashboard**: Added "Per-Step Metrics" row with step RPS, status codes, success rate, and p99 latency panels.

## Architecture

```
Node A ←── POST /config  (YAML body)
Node B ←── POST /config
Node C ←── POST /config

Each node: independent scenario workers → target servers
  Step 1: POST /auth/login → baseUrl (auth service)   ← cached per worker with TTL
  Step 2: GET  http://api-host/data                    ← full URL override (host B)

GET /health  (port 8080) → live JSON status
Prometheus scrapes all nodes (port 9090), per-step labels
```

## Example YAML (dual-host JWT flow with token cache)

```yaml
config:
  baseUrl: "http://192.168.2.23:31362"
  workers: 25
  duration: "75h"

load:
  model: "rps"
  target: 400

scenarios:
  - name: "JWT Auth → API call"
    weight: 100
    steps:
      - name: "Login — get JWT"
        request:
          method: "POST"
          path: "/auth/login"         # relative → baseUrl
          body: '{"email":"test@example.com","password":"password123"}'
          headers:
            Content-Type: "application/json"
        extract:
          - type: jsonPath
            name: "jwt_token"
            jsonPath: "$.token"
        cache:
          ttl: "1h"                   # reuse token per worker for 1 hour
        assertions:
          - type: statusCode
            expected: 200

      - name: "Call API with JWT"
        request:
          method: "GET"
          path: "http://api-host:9090/users/me"   # full URL → host B
          headers:
            Authorization: "Bearer ${jwt_token}"
        assertions:
          - type: statusCode
            expected: 200
          - type: responseTime
            max: "2s"

standby:
  workers: 2
  rps: 0
```

## Test plan

- [ ] CI passes (fmt + clippy + unit + integration tests)
- [ ] Docker image builds and pushes to `cbaugus/rust_loadtest:main`
- [ ] `POST /config` with scenarios — confirm scenario workers are spawned (not legacy single-URL worker)
- [ ] Multi-host: step with relative path hits `baseUrl`; step with full URL hits the specified host
- [ ] Session cache: login step fires once per worker; subsequent iterations reuse JWT until 1h TTL expires
- [ ] Per-step metrics appear in Prometheus with correct `scenario` and `step` labels
- [ ] RPS in `GET /health` counts every step HTTP request
- [ ] After test duration expires, `GET /health` returns `node_state: "standby"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)