### PR TITLE
feat: TENANT env var, musl static Debian image, LOG_FORMAT=json, bodySize, ephemeral GCP nodes

### DIFF
--- a/DOCKER_HUB_OVERVIEW.md
+++ b/DOCKER_HUB_OVERVIEW.md
@@ -144,6 +144,8 @@ docker run --rm \
 | `CLUSTER_NODE_ID` | No | hostname | Node identifier used in metrics labels |
 | `CLUSTER_REGION` | No | default | Region label used in metrics and health output |
 | `CLUSTER_HEALTH_ADDR` | No | 0.0.0.0:8080 | Bind address for the live control HTTP API |
+| `LOG_FORMAT` | No | pretty | Log output format: `json` for structured GCP/FluentBit logs, any other value for human-readable |
+| `RUST_LOG` | No | rust_loadtest=info | Log level filter (e.g. `rust_loadtest=warn,hyper=error,reqwest=error`) |
 
 ### Load Model Specific Variables
 
@@ -195,6 +197,30 @@ docker run --rm \
 openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
   -in original.key -out pkcs8.key
 ```
+
+## Structured Logging (GCP / FluentBit)
+
+Set `LOG_FORMAT=json` to emit one structured JSON object per log line instead of
+human-readable text. Required for FluentBit to unpack fields into GCP Cloud Logging
+`jsonPayload` so they are indexed, filterable, and priced as structured logs.
+
+```bash
+docker run --rm \
+  -e LOG_FORMAT=json \
+  -e RUST_LOG="rust_loadtest=warn,hyper=error,reqwest=error" \
+  -e TARGET_URL="https://api.example.com/endpoint" \
+  -e LOAD_MODEL_TYPE="Rps" \
+  -e TARGET_RPS="200" \
+  cbaugus/rust_loadtest:latest
+```
+
+**Example JSON log line:**
+```json
+{"timestamp":"2026-03-16T20:39:32.285Z","level":"WARN","target":"rust_loadtest::executor","fields":{"step":"GET /dashboard","status":404,"elapsed_ms":312}}
+```
+
+`RUST_LOG` accepts per-crate filters — setting `hyper=error,reqwest=error` suppresses
+HTTP client noise and significantly reduces log volume and cost.
 
 ## Advanced Features
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,19 @@
 # Multi-stage build for rust-loadtest
-# Stage 1: Build
-FROM rustlang/rust:nightly-slim AS builder
+#
+# Builder uses Alpine + musl to produce a fully static binary with no glibc
+# dependency, so the runtime image works on any Linux distro regardless of
+# the host glibc version.  reqwest already uses rustls (pure-Rust TLS) so
+# OpenSSL is not required at build or runtime.
+#
+# Stage 1: Build static binary
+FROM rust:alpine AS builder
 
 WORKDIR /app
 
-# Install dependencies
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+# musl-dev provides the musl libc headers for static linking
+RUN apk add --no-cache musl-dev
 
-# Copy manifests
+# Copy manifests first for better layer caching
 COPY Cargo.toml Cargo.lock ./
 
 # Copy source code
@@ -18,22 +21,23 @@ COPY src ./src
 COPY tests ./tests
 COPY examples ./examples
 
-# Build release binary
-RUN cargo build --release
+# Add musl target and build a fully static release binary
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo build --release --target x86_64-unknown-linux-musl
 
-# Stage 2: Runtime
+# Stage 2: Runtime (Debian for shell access, utilities, and CA certs)
 FROM debian:bookworm-slim
 
 WORKDIR /app
 
-# Install runtime dependencies
+# ca-certificates provides the system CA store for rustls-native-roots.
+# libssl3 is no longer needed — the binary uses rustls (pure-Rust TLS).
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the binary from builder (Cargo uses underscore)
-COPY --from=builder /app/target/release/rust_loadtest /usr/local/bin/rust-loadtest
+# Copy the static binary — no glibc symbols referenced
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/rust_loadtest /usr/local/bin/rust-loadtest
 
 # Copy example configs and data
 COPY examples/configs /app/configs

--- a/nomad/loadtest-consul-kv-example.nomad.hcl
+++ b/nomad/loadtest-consul-kv-example.nomad.hcl
@@ -188,6 +188,11 @@ TEST_DURATION=2h
 LOAD_MODEL_TYPE=Rps
 TARGET_RPS=0
 
+# ── Tenant label ─────────────────────────────────────────────────────────────
+# Applied to all Prometheus metrics emitted by this node from startup.
+# Overridden per-test by metadata.tenant in a POST /config YAML body.
+# TENANT=acme
+
 # ── Security (Issue #91 / #92) ────────────────────────────────────────────────
 # Uncomment to protect POST /config and POST /stop with a bearer token:
 # API_AUTH_TOKEN=your-secret-token-here

--- a/nomad/loadtest-consul-kv-example.nomad.hcl
+++ b/nomad/loadtest-consul-kv-example.nomad.hcl
@@ -174,7 +174,12 @@ job "envoy-loadtest" {
 # runs at startup before the Raft cluster forms and before the leader can fetch
 # from Consul KV.  The values here are replaced cluster-wide as soon as the
 # leader commits the Consul KV config to the Raft log.
-RUST_LOG=rust_loadtest=warn
+RUST_LOG=rust_loadtest=warn,hyper=error,reqwest=error
+# ── Logging format (Issue #101) ───────────────────────────────────────────────
+# LOG_FORMAT=json emits one structured JSON object per line — required for
+# FluentBit to unpack fields into GCP Cloud Logging jsonPayload.
+# Omit or set to any other value for human-readable output (local dev).
+LOG_FORMAT=json
 TARGET_URL=http://dialtone.service.consul:5678
 REQUEST_TYPE=GET
 SKIP_TLS_VERIFY=true

--- a/src/main.rs
+++ b/src/main.rs
@@ -777,7 +777,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         node_state: if ephemeral { "ready" } else { "running" },
         generation: 0,
         standby: None,
-        tenant: if startup_tenant.is_empty() { None } else { Some(startup_tenant.clone()) },
+        tenant: if startup_tenant.is_empty() {
+            None
+        } else {
+            Some(startup_tenant.clone())
+        },
     }));
 
     // ── Standalone health + config HTTP server ─────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -673,6 +673,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .and_then(|s| rust_loadtest::utils::parse_duration_string(&s).ok())
         .unwrap_or(Duration::from_secs(60));
 
+    // Tenant label applied to all Prometheus metrics for this node.
+    // Overridden per-test by the `metadata.tenant` field in a POSTed YAML config.
+    let startup_tenant = std::env::var("TENANT").unwrap_or_default();
+
     // Ephemeral nodes receive their real TARGET_URL from POST /config.
     // Set a placeholder so Config::from_env() doesn't fail at startup.
     if ephemeral && std::env::var("TARGET_URL").is_err() {
@@ -773,7 +777,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         node_state: if ephemeral { "ready" } else { "running" },
         generation: 0,
         standby: None,
-        tenant: None,
+        tenant: if startup_tenant.is_empty() { None } else { Some(startup_tenant.clone()) },
     }));
 
     // ── Standalone health + config HTTP server ─────────────────────────────
@@ -1545,8 +1549,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 percentile_tracking_enabled: config.percentile_tracking_enabled,
                 percentile_sampling_rate: config.percentile_sampling_rate,
                 region: config.cluster.region.clone(),
-                // No tenant when running from env-var config (no YAML submitted yet).
-                tenant: String::new(),
+                // Tenant from TENANT env var; overridden by metadata.tenant in POST /config.
+                tenant: startup_tenant.clone(),
                 // Graceful-stop signal (Issue #79). In cluster mode the
                 // config-watcher fires this before replacing the worker pool.
                 // In standalone mode it is never fired; workers self-terminate


### PR DESCRIPTION
## Summary

Four feature areas and supporting fixes, all CI-green.

### `TENANT` env var at startup
- `TENANT=acme` seeds the tenant label on all Prometheus metrics from process start — no `POST /config` required
- A YAML config POSTed later still overrides it via `metadata.tenant` as before
- Nomad template updated with commented `TENANT=` example

### Debian image — musl static binary (fixes GLIBC_2.39 error)
- Switches builder from `rustlang/rust:nightly-slim` (glibc-linked, recently moved to Trixie/glibc 2.39) to `rust:alpine` + `x86_64-unknown-linux-musl`
- Produces a fully static binary — no glibc dependency, runs on any Linux distro (Ubuntu 20.04/22.04, Debian Bullseye, older CentOS, etc.)
- `libssl3` removed from runtime deps — `reqwest` already uses `rustls` (pure-Rust TLS)
- Mirrors the approach already used by `Dockerfile.chainguard`

### `LOG_FORMAT=json` structured logging (closes #101)
- `LOG_FORMAT=json` emits one structured JSON object per log line for FluentBit/GCP Cloud Logging
- `LOG_FORMAT=pretty` (or unset) preserves human-readable output for local dev
- `RUST_LOG` filter extended to `rust_loadtest=warn,hyper=error,reqwest=error` in Nomad template to suppress HTTP client noise
- Docker Hub overview updated with new "Structured Logging" section and env vars table entries

### `bodySize` synthetic large-payload testing (closes #96)
- `bodySize: "1MB"` on a step generates random bytes of the given size per request (`B`, `KB`, `MB`)
- Mutually exclusive with `body` — validated at config load time
- New example template: `examples/configs/large-payload-test.yaml`

### Ephemeral GCP node lifecycle (closes #97, closes #98)
- `EPHEMERAL=true` — node starts in `ready` state, skips startup workers, self-destructs after test
- `POST /config` returns JSON node identity: `{"status":"accepted","node_id":...,"node_name":...,"region":...}`
- `EPHEMERAL_FINAL_SCRAPE_DELAY` (default 60s) holds `/metrics` + `/health` alive after test so GMP can scrape final totals
- `SELF_DESTRUCT_CMD` fires after the delay (e.g. `shutdown -h now` on GCP)
- State machine: `ready → running → idle` (ephemeral) vs `running → standby` (persistent)

## Test plan
- [ ] CI passes ✅
- [ ] `TENANT=acme` — Prometheus metrics carry `tenant="acme"` label from startup
- [ ] Debian image runs on Ubuntu 20.04 (glibc 2.31) without GLIBC error
- [ ] `LOG_FORMAT=json` — each log line is a valid JSON object with `level`, `target`, `fields`
- [ ] `bodySize: "512KB"` step sends correct `Content-Length`
- [ ] Ephemeral node starts in `ready`, transitions to `running` on `POST /config`, `idle` on completion
- [ ] `/metrics` reachable for full `EPHEMERAL_FINAL_SCRAPE_DELAY` after test ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)