### PR TITLE
feat: register once at startup, TENANT env var, musl Debian image, LOG_FORMAT=json

### DIFF
--- a/nomad/loadtest-consul-kv-example.nomad.hcl
+++ b/nomad/loadtest-consul-kv-example.nomad.hcl
@@ -207,7 +207,6 @@ TARGET_RPS=0
 # NODE_BASE_URL=http://{{env "attr.unique.network.ip-address"}}:8080
 # NODE_NAME={{env "node.unique.name"}}
 # NODE_TAGS={"env":"staging","datacenter":"{{env "node.datacenter"}}"}
-# NODE_REGISTRY_INTERVAL=30s
 
 # ── Ephemeral node / GCP one-shot (Issue #98) ────────────────────────────
 # EPHEMERAL=true starts the node in "ready" state (no startup workers).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1055,8 +1055,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         info!(
             registry_url = %reg_cfg.registry_url,
             node = %reg_cfg.node_name,
-            interval_secs = reg_cfg.interval.as_secs(),
-            "Auto-registration enabled"
+            "Auto-registration enabled — registering once at startup"
         );
         rust_loadtest::registry::spawn_registration_task(client.clone(), reg_cfg);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -409,7 +409,7 @@ fn print_config_help() {
     eprintln!("  NODE_BASE_URL           - This node's reachable URL (e.g. http://10.0.1.5:8080)");
     eprintln!("  NODE_NAME               - Human-readable node name (default: CLUSTER_NODE_ID)");
     eprintln!("  NODE_TAGS               - JSON tags object (default: {{}})");
-    eprintln!("  NODE_REGISTRY_INTERVAL  - Heartbeat interval (default: 30s)");
+    eprintln!("  NODE_REGISTRY_INTERVAL  - DEPRECATED: ignored. Control plane polls GET /health");
     eprintln!("Ephemeral node (GCP / one-shot) configuration:");
     eprintln!("  EPHEMERAL               - Set to 'true' for ephemeral (one-time-use) nodes");
     eprintln!("                            Node starts in 'ready' state, skips startup workers,");

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -15,7 +15,7 @@
 //! warning is logged.
 
 use reqwest::Client;
-use tracing::{info, warn, error};
+use tracing::{error, info, warn};
 
 /// Configuration for auto-registration, built from environment variables.
 pub struct RegistrationConfig {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,17 +1,21 @@
 //! Node auto-registration with the web app registry (Issue #89).
 //!
 //! When `NODE_REGISTRY_URL`, `AUTO_REGISTER_PSK`, and `NODE_BASE_URL` are all
-//! set, the node POSTs its identity to the web app at startup and re-registers
-//! at a configurable interval (heartbeat) to keep its record alive.
+//! set, the node POSTs its identity to the web app **once at startup**.
+//!
+//! The control plane is expected to poll each node's `GET /health` endpoint
+//! on its own schedule to track liveness and runtime metrics (webload-gui#82).
+//! Periodic re-registration from the node side is no longer needed and has
+//! been removed (Issue #104).
 //!
 //! If any of the three required env vars is missing, registration is silently
 //! skipped — the node operates exactly as before (fully backwards-compatible).
+//!
+//! `NODE_REGISTRY_INTERVAL` is **deprecated** — if set it is ignored and a
+//! warning is logged.
 
 use reqwest::Client;
-use std::time::Duration;
-use tracing::{error, info, warn};
-
-use crate::utils::parse_duration_string;
+use tracing::{info, warn, error};
 
 /// Configuration for auto-registration, built from environment variables.
 pub struct RegistrationConfig {
@@ -27,8 +31,6 @@ pub struct RegistrationConfig {
     pub region: String,
     /// Arbitrary JSON tags, e.g. `{"env":"staging","rack":"A"}`.
     pub tags: serde_json::Value,
-    /// How often to re-register (heartbeat). Default: 30 s.
-    pub interval: Duration,
 }
 
 impl RegistrationConfig {
@@ -56,17 +58,22 @@ impl RegistrationConfig {
             }
         };
 
+        // NODE_REGISTRY_INTERVAL is deprecated — the control plane now polls
+        // GET /health instead of relying on node-side heartbeats (Issue #104).
+        if std::env::var("NODE_REGISTRY_INTERVAL").is_ok() {
+            warn!(
+                "NODE_REGISTRY_INTERVAL is deprecated and ignored — \
+                 the control plane polls GET /health for liveness (webload-gui#82). \
+                 Remove this variable from your configuration."
+            );
+        }
+
         let node_name = std::env::var("NODE_NAME").unwrap_or_else(|_| node_id.to_string());
 
         let tags = std::env::var("NODE_TAGS")
             .ok()
             .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
             .unwrap_or_else(|| serde_json::json!({}));
-
-        let interval = std::env::var("NODE_REGISTRY_INTERVAL")
-            .ok()
-            .and_then(|s| parse_duration_string(&s).ok())
-            .unwrap_or(Duration::from_secs(30));
 
         Some(Self {
             registry_url,
@@ -75,7 +82,6 @@ impl RegistrationConfig {
             node_name,
             region: region.to_string(),
             tags,
-            interval,
         })
     }
 }
@@ -129,19 +135,10 @@ pub async fn register_once(client: &Client, cfg: &RegistrationConfig) -> bool {
     }
 }
 
-/// Spawn a background task that registers immediately then re-registers at
-/// `cfg.interval`.  All failures are logged; the task never crashes the node.
+/// Register the node with the web app once at startup.
+/// The control plane polls `GET /health` for ongoing liveness (webload-gui#82).
 pub fn spawn_registration_task(client: Client, cfg: RegistrationConfig) {
     tokio::spawn(async move {
-        // Register immediately on startup.
         register_once(&client, &cfg).await;
-
-        // Heartbeat loop — keeps the node alive in the registry.
-        let mut ticker = tokio::time::interval(cfg.interval);
-        ticker.tick().await; // first tick fires immediately; skip it
-        loop {
-            ticker.tick().await;
-            register_once(&client, &cfg).await;
-        }
     });
 }


### PR DESCRIPTION
## Summary

Four improvements, all CI-green on `dev`.

### Register once at startup — remove periodic re-registration (closes #104)

Node-side heartbeats to the control plane are replaced by the control plane
polling `GET /health` on each node (webload-gui#82).

- `spawn_registration_task` registers exactly once at startup and exits — no ticker, no loop
- `RegistrationConfig.interval` field removed
- `NODE_REGISTRY_INTERVAL` is **deprecated**: if set, a warning is logged and it is ignored
- Help output marks `NODE_REGISTRY_INTERVAL` as deprecated
- Nomad template: `NODE_REGISTRY_INTERVAL` comment removed

**Before:** every node POSTs a re-registration to the control plane every 30 s, flooding
Cloud Logging and adding DB write load at scale.
**After:** one registration at startup; liveness is owned by the control plane poller.

### `TENANT` env var at startup

- `TENANT=acme` seeds the tenant label on all Prometheus metrics from process start
- A YAML config POSTed later still overrides it via `metadata.tenant` as before
- Nomad template updated with commented example

### Debian image — musl static binary (fixes `GLIBC_2.39` not found)

- Builder switched from `rustlang/rust:nightly-slim` (glibc-linked) to `rust:alpine` + `x86_64-unknown-linux-musl`
- Fully static binary — runs on Ubuntu 20.04, Debian Bullseye, any Linux regardless of glibc version
- `libssl3` removed from runtime — `reqwest` uses `rustls` (pure-Rust TLS)
- Mirrors `Dockerfile.chainguard`; only the runtime stage differs (Debian instead of Chainguard static)

### `LOG_FORMAT=json` structured logging for GCP / FluentBit (closes #101)

- `LOG_FORMAT=json` emits one structured JSON object per line — FluentBit can unpack fields into GCP `jsonPayload`
- `LOG_FORMAT=pretty` (default) preserves human-readable output
- `RUST_LOG` extended to `rust_loadtest=warn,hyper=error,reqwest=error` in Nomad template
- Docker Hub overview updated with "Structured Logging" section and env vars table entries

## Test plan
- [ ] CI passes ✅
- [ ] Node appears in webload-gui registry exactly once after startup (no repeated entries)
- [ ] `NODE_REGISTRY_INTERVAL` set → deprecation warning logged, no re-registration timer
- [ ] `TENANT=acme` → Prometheus metrics carry `tenant="acme"` from startup
- [ ] Debian image runs on Ubuntu 20.04 without GLIBC error
- [ ] `LOG_FORMAT=json` → each log line is valid JSON with `level`, `target`, `fields`

🤖 Generated with [Claude Code](https://claude.com/claude-code)