### PR TITLE
feat: Phase 2-4 — scenarios, cluster health, standalone mode, and observability

### DIFF
--- a/examples/scenario_example.rs
+++ b/examples/scenario_example.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create scenario executor
     let base_url = "https://ecom.edge.baugus-lab.com".to_string();
-    let executor = ScenarioExecutor::new(base_url, client);
+    let executor = ScenarioExecutor::new(base_url, client, "local".to_string(), "run-0".to_string());
 
     // Execute the scenario
     let mut context = ScenarioContext::new();

--- a/examples/scenario_example.rs
+++ b/examples/scenario_example.rs
@@ -28,7 +28,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create scenario executor
     let base_url = "https://ecom.edge.baugus-lab.com".to_string();
-    let executor = ScenarioExecutor::new(base_url, client, "local".to_string(), "run-0".to_string());
+    let executor =
+        ScenarioExecutor::new(base_url, client, "local".to_string(), "run-0".to_string());
 
     // Execute the scenario
     let mut context = ScenarioContext::new();

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -107,6 +107,12 @@ pub struct ScenarioExecutor {
     /// HTTP client for making requests
     /// Should have cookie_store(true) enabled for session management
     client: reqwest::Client,
+
+    /// Node identifier attached to all metrics (Issue #106).
+    node_id: String,
+
+    /// Run identifier attached to all metrics (Issue #106).
+    run_id: String,
 }
 
 impl ScenarioExecutor {
@@ -116,23 +122,15 @@ impl ScenarioExecutor {
     /// * `base_url` - Base URL for all requests in the scenario
     /// * `client` - HTTP client to use for requests. Should have `cookie_store(true)`
     ///   enabled for automatic cookie and session management.
-    ///
-    /// # Example
-    /// ```rust
-    /// use rust_loadtest::executor::ScenarioExecutor;
-    ///
-    /// let client = reqwest::Client::builder()
-    ///     .cookie_store(true)  // Enable cookies
-    ///     .build()
-    ///     .unwrap();
-    ///
-    /// let executor = ScenarioExecutor::new(
-    ///     "https://api.example.com".to_string(),
-    ///     client
-    /// );
-    /// ```
-    pub fn new(base_url: String, client: reqwest::Client) -> Self {
-        Self { base_url, client }
+    /// * `node_id` - Node identifier attached to all metrics (Issue #106)
+    /// * `run_id` - Run identifier attached to all metrics (Issue #106)
+    pub fn new(base_url: String, client: reqwest::Client, node_id: String, run_id: String) -> Self {
+        Self {
+            base_url,
+            client,
+            node_id,
+            run_id,
+        }
     }
 
     /// Execute a scenario with the given context.
@@ -224,12 +222,12 @@ impl ScenarioExecutor {
         // Record scenario metrics
         CONCURRENT_SCENARIOS.dec();
         SCENARIO_DURATION_SECONDS
-            .with_label_values(&[&scenario.name])
+            .with_label_values(&[&scenario.name, &self.node_id, &self.run_id])
             .observe(total_time_secs);
 
         let status = if all_success { "success" } else { "failed" };
         SCENARIO_EXECUTIONS_TOTAL
-            .with_label_values(&[&scenario.name, status])
+            .with_label_values(&[&scenario.name, status, &self.node_id, &self.run_id])
             .inc();
 
         if all_success {
@@ -459,7 +457,13 @@ impl ScenarioExecutor {
                                 // Record assertion metrics
                                 let result_label = if result.passed { "passed" } else { "failed" };
                                 SCENARIO_ASSERTIONS_TOTAL
-                                    .with_label_values(&[scenario_name, &step.name, result_label])
+                                    .with_label_values(&[
+                                        scenario_name,
+                                        &step.name,
+                                        result_label,
+                                        &self.node_id,
+                                        &self.run_id,
+                                    ])
                                     .inc();
                             }
 
@@ -515,17 +519,29 @@ impl ScenarioExecutor {
                 // Record step metrics
                 let response_time_secs = response_time_ms as f64 / 1000.0;
                 SCENARIO_STEP_DURATION_SECONDS
-                    .with_label_values(&[scenario_name, &step.name])
+                    .with_label_values(&[scenario_name, &step.name, &self.node_id, &self.run_id])
                     .observe(response_time_secs);
 
                 let status_code_str = status.as_u16().to_string();
                 SCENARIO_STEP_STATUS_CODES
-                    .with_label_values(&[scenario_name, &step.name, &status_code_str])
+                    .with_label_values(&[
+                        scenario_name,
+                        &step.name,
+                        &status_code_str,
+                        &self.node_id,
+                        &self.run_id,
+                    ])
                     .inc();
 
                 let step_status = if success { "success" } else { "failed" };
                 SCENARIO_STEPS_TOTAL
-                    .with_label_values(&[scenario_name, &step.name, step_status])
+                    .with_label_values(&[
+                        scenario_name,
+                        &step.name,
+                        step_status,
+                        &self.node_id,
+                        &self.run_id,
+                    ])
                     .inc();
 
                 debug!(
@@ -558,7 +574,13 @@ impl ScenarioExecutor {
 
                 // Record failed step metrics
                 SCENARIO_STEPS_TOTAL
-                    .with_label_values(&[scenario_name, &step.name, "failed"])
+                    .with_label_values(&[
+                        scenario_name,
+                        &step.name,
+                        "failed",
+                        &self.node_id,
+                        &self.run_id,
+                    ])
                     .inc();
 
                 StepResult {
@@ -633,7 +655,12 @@ mod tests {
     #[tokio::test]
     async fn test_executor_creation() {
         let client = reqwest::Client::new();
-        let executor = ScenarioExecutor::new("https://example.com".to_string(), client);
+        let executor = ScenarioExecutor::new(
+            "https://example.com".to_string(),
+            client,
+            "test-node".to_string(),
+            "run-0".to_string(),
+        );
 
         assert_eq!(executor.base_url, "https://example.com");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,6 +485,7 @@ struct StandbyRunConfig {
     percentile_tracking_enabled: bool,
     percentile_sampling_rate: u8,
     region: String,
+    node_id: String,
 }
 
 /// Tracks the active test run — shared between the config-watcher and metrics updater.
@@ -498,6 +499,10 @@ struct TestState {
     standby: Option<StandbyRunConfig>,
     /// Tenant identifier for the active test run. None when no tenant is set.
     tenant: Option<String>,
+    /// Run identifier (Issue #106). Unique per test dispatch; auto-generated at
+    /// startup and reset on each POST /config from `metadata.run_id` or a new
+    /// Unix-timestamp value.
+    run_id: String,
 }
 
 /// Returns the current Unix timestamp in seconds.
@@ -604,6 +609,8 @@ fn spawn_completion_watcher(
                     percentile_sampling_rate: sb.percentile_sampling_rate,
                     region: sb.region.clone(),
                     tenant: String::new(), // standby mode has no tenant
+                    node_id: sb.node_id.clone(),
+                    run_id: String::new(), // standby mode has no run_id
                     stop_rx: new_stop_rx.clone(),
                 };
                 tokio::spawn(run_worker(client.clone(), wc, new_start))
@@ -720,6 +727,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         percentile_tracking_enabled: config.percentile_tracking_enabled,
         percentile_sampling_rate: config.percentile_sampling_rate,
         region: config.cluster.region.clone(),
+        node_id: config.cluster.node_id.clone(),
     });
 
     // Start the Prometheus metrics HTTP server
@@ -782,6 +790,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         } else {
             Some(startup_tenant.clone())
         },
+        run_id: format!("run-{}", unix_now()),
     }));
 
     // ── Standalone health + config HTTP server ─────────────────────────────
@@ -863,7 +872,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                                         }
                                     }
                                     let m = lm.lock().unwrap().clone();
-                                    let current_tenant = ts.lock().unwrap().tenant.clone();
+                                    let (current_tenant, current_run_id) = {
+                                        let st = ts.lock().unwrap();
+                                        (st.tenant.clone(), st.run_id.clone())
+                                    };
                                     let body = serde_json::json!({
                                         "status": "ok",
                                         "node_id": node_id,
@@ -871,6 +883,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                                         "region": region,
                                         "ephemeral": ephemeral,
                                         "tenant": current_tenant,
+                                        "run_id": current_run_id,
                                         "node_state": m.node_state,
                                         "rps": (m.rps * 100.0).round() / 100.0,
                                         "error_rate_pct": (m.error_rate_pct * 100.0).round() / 100.0,
@@ -1066,6 +1079,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let pool_for_watcher = worker_pool.clone();
         let client_for_watcher = client.clone();
         let region_for_watcher = config.cluster.region.clone();
+        let node_id_for_watcher = config.cluster.node_id.clone();
         let test_state_for_watcher = test_state.clone();
         let startup_standby_for_watcher = startup_standby.clone();
         let ephemeral_for_watcher = ephemeral;
@@ -1096,6 +1110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     percentile_tracking_enabled: new_cfg.percentile_tracking_enabled,
                     percentile_sampling_rate: new_cfg.percentile_sampling_rate,
                     region: region_for_watcher.clone(),
+                    node_id: node_id_for_watcher.clone(),
                 });
 
                 info!(
@@ -1134,6 +1149,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 let (new_stop_tx, new_stop_rx) = watch::channel(false);
                 let new_start = time::Instant::now();
                 let new_tenant = yaml_cfg_parsed.metadata.tenant.clone();
+                let new_run_id = yaml_cfg_parsed
+                    .metadata
+                    .run_id
+                    .clone()
+                    .unwrap_or_else(|| format!("run-{}", unix_now()));
 
                 // If the YAML contains scenarios, use scenario workers; otherwise
                 // fall back to the legacy single-URL worker.
@@ -1160,6 +1180,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                                         percentile_sampling_rate: new_cfg.percentile_sampling_rate,
                                         region: region_for_watcher.clone(),
                                         tenant: new_tenant.clone().unwrap_or_default(),
+                                        node_id: node_id_for_watcher.clone(),
+                                        run_id: new_run_id.clone(),
                                     };
                                     tokio::spawn(run_scenario_worker(
                                         new_client.clone(),
@@ -1187,6 +1209,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                                         percentile_sampling_rate: new_cfg.percentile_sampling_rate,
                                         region: region_for_watcher.clone(),
                                         tenant: new_tenant.clone().unwrap_or_default(),
+                                        node_id: node_id_for_watcher.clone(),
+                                        run_id: new_run_id.clone(),
                                         stop_rx: new_stop_rx.clone(),
                                     };
                                     tokio::spawn(run_worker(new_client.clone(), wc, new_start))
@@ -1210,6 +1234,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                                 percentile_sampling_rate: new_cfg.percentile_sampling_rate,
                                 region: region_for_watcher.clone(),
                                 tenant: new_tenant.clone().unwrap_or_default(),
+                                node_id: node_id_for_watcher.clone(),
+                                run_id: new_run_id.clone(),
                                 stop_rx: new_stop_rx.clone(),
                             };
                             tokio::spawn(run_worker(new_client.clone(), wc, new_start))
@@ -1233,6 +1259,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     ts.generation += 1;
                     ts.standby = standby_cfg;
                     ts.tenant = new_tenant.clone();
+                    ts.run_id = new_run_id.clone();
                     ts.generation
                 };
                 spawn_completion_watcher(
@@ -1308,11 +1335,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let live_metrics_for_updater = live_metrics.clone();
         let test_state_for_updater = test_state.clone();
         let region = config.cluster.region.clone();
+        let node_id_for_updater = config.cluster.node_id.clone();
         tokio::spawn(async move {
             let mut interval = time::interval(Duration::from_secs(1));
             let mut prev_requests: u64 = 0;
             let mut prev_errors: u64 = 0;
-            let mut prev_tenant: String = String::new();
+            let mut prev_run_id: String = String::new();
             // CPU tracking (Linux only) — tracks utime+stime jiffies
             #[cfg(target_os = "linux")]
             let mut prev_cpu_ticks: Option<u64> = None;
@@ -1321,21 +1349,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 interval.tick().await;
 
                 // ── Request counter (monotonic) ──────────────────────────
-                let tenant_str = test_state_for_updater
-                    .lock()
-                    .unwrap()
-                    .tenant
-                    .clone()
-                    .unwrap_or_default();
-                // Reset delta tracking when the active tenant changes so we
+                let (tenant_str, run_id_str) = {
+                    let ts = test_state_for_updater.lock().unwrap();
+                    (ts.tenant.clone().unwrap_or_default(), ts.run_id.clone())
+                };
+                // Reset delta tracking when the active run changes so we
                 // don't compute a nonsensical RPS across test boundaries.
-                if tenant_str != prev_tenant {
+                if run_id_str != prev_run_id {
                     prev_requests = 0;
                     prev_errors = 0;
-                    prev_tenant = tenant_str.clone();
+                    prev_run_id = run_id_str.clone();
                 }
                 let curr_requests = REQUEST_TOTAL
-                    .with_label_values(&[&region, &tenant_str])
+                    .with_label_values(&[&region, &tenant_str, &node_id_for_updater, &run_id_str])
                     .get();
 
                 // ── Error counter: sum all known categories ───────────────
@@ -1343,7 +1369,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     .iter()
                     .map(|cat| {
                         REQUEST_ERRORS_BY_CATEGORY
-                            .with_label_values(&[cat.label(), &region, &tenant_str])
+                            .with_label_values(&[
+                                cat.label(),
+                                &region,
+                                &tenant_str,
+                                &node_id_for_updater,
+                                &run_id_str,
+                            ])
                             .get()
                     })
                     .sum();
@@ -1554,6 +1586,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 region: config.cluster.region.clone(),
                 // Tenant from TENANT env var; overridden by metadata.tenant in POST /config.
                 tenant: startup_tenant.clone(),
+                node_id: config.cluster.node_id.clone(),
+                run_id: test_state.lock().unwrap().run_id.clone(),
                 // Graceful-stop signal (Issue #79). In cluster mode the
                 // config-watcher fires this before replacing the worker pool.
                 // In standalone mode it is never fired; workers self-terminate

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -17,21 +17,21 @@ lazy_static::lazy_static! {
         IntCounterVec::new(
             Opts::new("requests_total", "Total number of HTTP requests made")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["region", "tenant"]
+            &["region", "tenant", "node_id", "run_id"]
         ).unwrap();
 
     pub static ref REQUEST_STATUS_CODES: IntCounterVec =
         IntCounterVec::new(
             Opts::new("requests_status_codes_total", "Number of HTTP requests by status code")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["status_code", "region", "tenant"]
+            &["status_code", "region", "tenant", "node_id", "run_id"]
         ).unwrap();
 
     pub static ref CONCURRENT_REQUESTS: prometheus::GaugeVec =
         prometheus::GaugeVec::new(
             Opts::new("concurrent_requests", "Number of HTTP requests currently in flight")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["region", "tenant"]
+            &["region", "tenant", "node_id", "run_id"]
         ).unwrap();
 
     pub static ref REQUEST_DURATION_SECONDS: HistogramVec =
@@ -40,7 +40,7 @@ lazy_static::lazy_static! {
                 "request_duration_seconds",
                 "HTTP request latencies in seconds."
             ).namespace(METRIC_NAMESPACE.as_str()),
-            &["region", "tenant"]
+            &["region", "tenant", "node_id", "run_id"]
         ).unwrap();
 
     // === Scenario Metrics ===
@@ -49,7 +49,7 @@ lazy_static::lazy_static! {
         IntCounterVec::new(
             Opts::new("scenario_executions_total", "Total number of scenario executions")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["scenario", "status"]  // status: success, failed
+            &["scenario", "status", "node_id", "run_id"]  // status: success, failed
         ).unwrap();
 
     pub static ref SCENARIO_DURATION_SECONDS: HistogramVec =
@@ -58,14 +58,14 @@ lazy_static::lazy_static! {
                 "scenario_duration_seconds",
                 "Scenario execution duration in seconds"
             ).namespace(METRIC_NAMESPACE.as_str()),
-            &["scenario"]
+            &["scenario", "node_id", "run_id"]
         ).unwrap();
 
     pub static ref SCENARIO_STEPS_TOTAL: IntCounterVec =
         IntCounterVec::new(
             Opts::new("scenario_steps_total", "Total number of scenario steps executed")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["scenario", "step", "status"]  // status: success, failed
+            &["scenario", "step", "status", "node_id", "run_id"]  // status: success, failed
         ).unwrap();
 
     pub static ref SCENARIO_STEP_DURATION_SECONDS: HistogramVec =
@@ -74,21 +74,21 @@ lazy_static::lazy_static! {
                 "scenario_step_duration_seconds",
                 "Scenario step duration in seconds"
             ).namespace(METRIC_NAMESPACE.as_str()),
-            &["scenario", "step"]
+            &["scenario", "step", "node_id", "run_id"]
         ).unwrap();
 
     pub static ref SCENARIO_STEP_STATUS_CODES: IntCounterVec =
         IntCounterVec::new(
             Opts::new("scenario_step_status_codes_total", "HTTP status codes per scenario step")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["scenario", "step", "status_code"]
+            &["scenario", "step", "status_code", "node_id", "run_id"]
         ).unwrap();
 
     pub static ref SCENARIO_ASSERTIONS_TOTAL: IntCounterVec =
         IntCounterVec::new(
             Opts::new("scenario_assertions_total", "Total number of scenario assertions")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["scenario", "step", "result"]  // result: passed, failed
+            &["scenario", "step", "result", "node_id", "run_id"]  // result: passed, failed
         ).unwrap();
 
     pub static ref CONCURRENT_SCENARIOS: Gauge =
@@ -103,7 +103,7 @@ lazy_static::lazy_static! {
         IntCounterVec::new(
             Opts::new("scenario_requests_total", "Total number of requests per scenario")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["scenario", "tenant"]
+            &["scenario", "tenant", "node_id", "run_id"]
         ).unwrap();
 
     pub static ref SCENARIO_THROUGHPUT_RPS: prometheus::GaugeVec =
@@ -119,7 +119,7 @@ lazy_static::lazy_static! {
         IntCounterVec::new(
             Opts::new("request_errors_by_category", "Number of errors by category")
                 .namespace(METRIC_NAMESPACE.as_str()),
-            &["category", "region", "tenant"]
+            &["category", "region", "tenant", "node_id", "run_id"]
         ).unwrap();
 
     // === Connection Pool Metrics (Issue #36) ===

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -55,6 +55,13 @@ pub struct WorkerConfig {
     /// Attached as a `tenant` label to all request metrics so per-tenant
     /// request counts can be queried from Prometheus for billing.
     pub tenant: String,
+    /// Node identifier (Issue #106). Attached as a `node_id` label to all
+    /// request metrics so metrics can be filtered per node in Prometheus.
+    pub node_id: String,
+    /// Run identifier (Issue #106). Unique per test dispatch; auto-generated
+    /// if absent from the YAML `metadata.run_id` field.  Attached as a
+    /// `run_id` label so sequential tests on the same node can be isolated.
+    pub run_id: String,
     /// Graceful-stop signal (Issue #79).  When the sender fires `true` the
     /// worker finishes its current request and exits at the top of the next
     /// loop iteration so no in-flight request is aborted.
@@ -141,10 +148,10 @@ pub async fn run_worker(client: reqwest::Client, config: WorkerConfig, start_tim
 
         // Track metrics
         CONCURRENT_REQUESTS
-            .with_label_values(&[&config.region, &config.tenant])
+            .with_label_values(&[&config.region, &config.tenant, &config.node_id, &config.run_id])
             .inc();
         REQUEST_TOTAL
-            .with_label_values(&[&config.region, &config.tenant])
+            .with_label_values(&[&config.region, &config.tenant, &config.node_id, &config.run_id])
             .inc();
 
         let request_start_time = time::Instant::now();
@@ -158,13 +165,25 @@ pub async fn run_worker(client: reqwest::Client, config: WorkerConfig, start_tim
                 // Use static strings to avoid a heap allocation on every request
                 let status_str = status_code_label(status);
                 REQUEST_STATUS_CODES
-                    .with_label_values(&[status_str, &config.region, &config.tenant])
+                    .with_label_values(&[
+                        status_str,
+                        &config.region,
+                        &config.tenant,
+                        &config.node_id,
+                        &config.run_id,
+                    ])
                     .inc();
 
                 // Categorize HTTP errors (Issue #34)
                 if let Some(category) = ErrorCategory::from_status_code(status) {
                     REQUEST_ERRORS_BY_CATEGORY
-                        .with_label_values(&[category.label(), &config.region, &config.tenant])
+                        .with_label_values(&[
+                            category.label(),
+                            &config.region,
+                            &config.tenant,
+                            &config.node_id,
+                            &config.run_id,
+                        ])
                         .inc();
                 }
 
@@ -185,13 +204,25 @@ pub async fn run_worker(client: reqwest::Client, config: WorkerConfig, start_tim
             }
             Err(e) => {
                 REQUEST_STATUS_CODES
-                    .with_label_values(&["error", &config.region, &config.tenant])
+                    .with_label_values(&[
+                        "error",
+                        &config.region,
+                        &config.tenant,
+                        &config.node_id,
+                        &config.run_id,
+                    ])
                     .inc();
 
                 // Categorize request error (Issue #34)
                 let error_category = ErrorCategory::from_reqwest_error(&e);
                 REQUEST_ERRORS_BY_CATEGORY
-                    .with_label_values(&[error_category.label(), &config.region, &config.tenant])
+                    .with_label_values(&[
+                        error_category.label(),
+                        &config.region,
+                        &config.tenant,
+                        &config.node_id,
+                        &config.run_id,
+                    ])
                     .inc();
 
                 error!(
@@ -207,10 +238,10 @@ pub async fn run_worker(client: reqwest::Client, config: WorkerConfig, start_tim
 
         let actual_latency_ms = request_start_time.elapsed().as_millis() as u64;
         REQUEST_DURATION_SECONDS
-            .with_label_values(&[&config.region, &config.tenant])
+            .with_label_values(&[&config.region, &config.tenant, &config.node_id, &config.run_id])
             .observe(request_start_time.elapsed().as_secs_f64());
         CONCURRENT_REQUESTS
-            .with_label_values(&[&config.region, &config.tenant])
+            .with_label_values(&[&config.region, &config.tenant, &config.node_id, &config.run_id])
             .dec();
 
         // Record latency in percentile tracker (Issue #33, #66, #70, #72)
@@ -318,6 +349,10 @@ pub struct ScenarioWorkerConfig {
     pub region: String,
     /// Optional tenant identifier. Empty string when no tenant is configured.
     pub tenant: String,
+    /// Node identifier (Issue #106).
+    pub node_id: String,
+    /// Run identifier (Issue #106). Unique per test dispatch.
+    pub run_id: String,
 }
 
 /// Runs a scenario-based worker task that executes multi-step scenarios according to the load model.
@@ -400,7 +435,12 @@ pub async fn run_scenario_worker(
             .unwrap_or_else(|_| reqwest::Client::new());
 
         // Create executor with isolated client
-        let executor = ScenarioExecutor::new(config.base_url.clone(), client);
+        let executor = ScenarioExecutor::new(
+            config.base_url.clone(),
+            client,
+            config.node_id.clone(),
+            config.run_id.clone(),
+        );
 
         // Create new context for this scenario execution
         let mut context = ScenarioContext::new();
@@ -443,21 +483,42 @@ pub async fn run_scenario_worker(
                 continue;
             }
             REQUEST_TOTAL
-                .with_label_values(&[&config.region, &config.tenant])
+                .with_label_values(&[
+                    &config.region,
+                    &config.tenant,
+                    &config.node_id,
+                    &config.run_id,
+                ])
                 .inc();
             if let Some(code) = step.status_code {
                 REQUEST_STATUS_CODES
-                    .with_label_values(&[status_code_label(code), &config.region, &config.tenant])
+                    .with_label_values(&[
+                        status_code_label(code),
+                        &config.region,
+                        &config.tenant,
+                        &config.node_id,
+                        &config.run_id,
+                    ])
                     .inc();
             }
             REQUEST_DURATION_SECONDS
-                .with_label_values(&[&config.region, &config.tenant])
+                .with_label_values(&[
+                    &config.region,
+                    &config.tenant,
+                    &config.node_id,
+                    &config.run_id,
+                ])
                 .observe(step.response_time_ms as f64 / 1000.0);
         }
 
         // Record throughput (Issue #35)
         SCENARIO_REQUESTS_TOTAL
-            .with_label_values(&[&config.scenario.name, &config.tenant])
+            .with_label_values(&[
+                &config.scenario.name,
+                &config.tenant,
+                &config.node_id,
+                &config.run_id,
+            ])
             .inc();
         GLOBAL_THROUGHPUT_TRACKER.record(
             &config.scenario.name,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -148,10 +148,20 @@ pub async fn run_worker(client: reqwest::Client, config: WorkerConfig, start_tim
 
         // Track metrics
         CONCURRENT_REQUESTS
-            .with_label_values(&[&config.region, &config.tenant, &config.node_id, &config.run_id])
+            .with_label_values(&[
+                &config.region,
+                &config.tenant,
+                &config.node_id,
+                &config.run_id,
+            ])
             .inc();
         REQUEST_TOTAL
-            .with_label_values(&[&config.region, &config.tenant, &config.node_id, &config.run_id])
+            .with_label_values(&[
+                &config.region,
+                &config.tenant,
+                &config.node_id,
+                &config.run_id,
+            ])
             .inc();
 
         let request_start_time = time::Instant::now();
@@ -238,10 +248,20 @@ pub async fn run_worker(client: reqwest::Client, config: WorkerConfig, start_tim
 
         let actual_latency_ms = request_start_time.elapsed().as_millis() as u64;
         REQUEST_DURATION_SECONDS
-            .with_label_values(&[&config.region, &config.tenant, &config.node_id, &config.run_id])
+            .with_label_values(&[
+                &config.region,
+                &config.tenant,
+                &config.node_id,
+                &config.run_id,
+            ])
             .observe(request_start_time.elapsed().as_secs_f64());
         CONCURRENT_REQUESTS
-            .with_label_values(&[&config.region, &config.tenant, &config.node_id, &config.run_id])
+            .with_label_values(&[
+                &config.region,
+                &config.tenant,
+                &config.node_id,
+                &config.run_id,
+            ])
             .dec();
 
         // Record latency in percentile tracker (Issue #33, #66, #70, #72)

--- a/src/yaml_config.rs
+++ b/src/yaml_config.rs
@@ -67,6 +67,11 @@ pub struct YamlMetadata {
     /// When set, all metrics emitted by this test run include a `tenant` label
     /// so per-tenant request counts can be queried from Prometheus.
     pub tenant: Option<String>,
+    /// Optional run identifier.  Auto-generated from the current Unix timestamp
+    /// if absent.  Included as a `run_id` label on all request and scenario
+    /// metrics so multiple sequential tests on the same node can be distinguished
+    /// in Prometheus (Issue #106).
+    pub run_id: Option<String>,
 }
 
 /// Global configuration settings.

--- a/tests/assertion_integration_tests.rs
+++ b/tests/assertion_integration_tests.rs
@@ -52,7 +52,7 @@ async fn test_status_code_assertion_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -98,7 +98,7 @@ async fn test_status_code_assertion_fail() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -144,7 +144,7 @@ async fn test_response_time_assertion_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -191,7 +191,7 @@ async fn test_response_time_assertion_fail() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -243,7 +243,7 @@ async fn test_json_path_assertion_existence() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -292,7 +292,7 @@ async fn test_json_path_assertion_value_match() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -341,7 +341,7 @@ async fn test_json_path_assertion_value_mismatch() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -390,7 +390,7 @@ async fn test_body_contains_assertion_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -436,7 +436,7 @@ async fn test_body_contains_assertion_fail() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -484,7 +484,7 @@ async fn test_body_matches_regex_assertion() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -527,7 +527,7 @@ async fn test_header_exists_assertion_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -571,7 +571,7 @@ async fn test_header_exists_assertion_fail() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -628,7 +628,7 @@ async fn test_multiple_assertions_all_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -680,7 +680,7 @@ async fn test_multiple_assertions_mixed_results() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -764,7 +764,7 @@ async fn test_multi_step_assertion_stops_on_failure() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -859,7 +859,7 @@ async fn test_realistic_e_commerce_flow_with_assertions() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(ECOM_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(ECOM_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/assertion_integration_tests.rs
+++ b/tests/assertion_integration_tests.rs
@@ -52,7 +52,12 @@ async fn test_status_code_assertion_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -98,7 +103,12 @@ async fn test_status_code_assertion_fail() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -144,7 +154,12 @@ async fn test_response_time_assertion_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -191,7 +206,12 @@ async fn test_response_time_assertion_fail() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -243,7 +263,12 @@ async fn test_json_path_assertion_existence() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -292,7 +317,12 @@ async fn test_json_path_assertion_value_match() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -341,7 +371,12 @@ async fn test_json_path_assertion_value_mismatch() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -390,7 +425,12 @@ async fn test_body_contains_assertion_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -436,7 +476,12 @@ async fn test_body_contains_assertion_fail() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -484,7 +529,12 @@ async fn test_body_matches_regex_assertion() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -527,7 +577,12 @@ async fn test_header_exists_assertion_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -571,7 +626,12 @@ async fn test_header_exists_assertion_fail() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -628,7 +688,12 @@ async fn test_multiple_assertions_all_pass() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -680,7 +745,12 @@ async fn test_multiple_assertions_mixed_results() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -764,7 +834,12 @@ async fn test_multi_step_assertion_stops_on_failure() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -859,7 +934,12 @@ async fn test_realistic_e_commerce_flow_with_assertions() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(ECOM_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        ECOM_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/cookie_session_tests.rs
+++ b/tests/cookie_session_tests.rs
@@ -72,7 +72,7 @@ async fn test_cookies_persist_across_steps() {
     };
 
     let client = create_cookie_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -168,7 +168,7 @@ async fn test_auth_flow_with_token_and_cookies() {
     };
 
     let client = create_cookie_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -242,8 +242,8 @@ async fn test_cookie_isolation_between_clients() {
     let client1 = create_cookie_client();
     let client2 = create_cookie_client();
 
-    let executor1 = ScenarioExecutor::new(BASE_URL.to_string(), client1);
-    let executor2 = ScenarioExecutor::new(BASE_URL.to_string(), client2);
+    let executor1 = ScenarioExecutor::new(BASE_URL.to_string(), client1, "test-node".to_string(), "run-0".to_string());
+    let executor2 = ScenarioExecutor::new(BASE_URL.to_string(), client2, "test-node".to_string(), "run-0".to_string());
 
     let mut context1 = ScenarioContext::new();
     let mut context2 = ScenarioContext::new();
@@ -367,7 +367,7 @@ async fn test_shopping_flow_with_session() {
     };
 
     let client = create_cookie_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -435,8 +435,8 @@ async fn test_client_without_cookies_fails_session() {
     // Client WITH cookies
     let client_with_cookies = create_cookie_client();
 
-    let executor_no_cookies = ScenarioExecutor::new(BASE_URL.to_string(), client_no_cookies);
-    let executor_with_cookies = ScenarioExecutor::new(BASE_URL.to_string(), client_with_cookies);
+    let executor_no_cookies = ScenarioExecutor::new(BASE_URL.to_string(), client_no_cookies, "test-node".to_string(), "run-0".to_string());
+    let executor_with_cookies = ScenarioExecutor::new(BASE_URL.to_string(), client_with_cookies, "test-node".to_string(), "run-0".to_string());
 
     let mut context_no_cookies = ScenarioContext::new();
     let mut context_with_cookies = ScenarioContext::new();

--- a/tests/cookie_session_tests.rs
+++ b/tests/cookie_session_tests.rs
@@ -72,7 +72,12 @@ async fn test_cookies_persist_across_steps() {
     };
 
     let client = create_cookie_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -168,7 +173,12 @@ async fn test_auth_flow_with_token_and_cookies() {
     };
 
     let client = create_cookie_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -242,8 +252,18 @@ async fn test_cookie_isolation_between_clients() {
     let client1 = create_cookie_client();
     let client2 = create_cookie_client();
 
-    let executor1 = ScenarioExecutor::new(BASE_URL.to_string(), client1, "test-node".to_string(), "run-0".to_string());
-    let executor2 = ScenarioExecutor::new(BASE_URL.to_string(), client2, "test-node".to_string(), "run-0".to_string());
+    let executor1 = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client1,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
+    let executor2 = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client2,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
 
     let mut context1 = ScenarioContext::new();
     let mut context2 = ScenarioContext::new();
@@ -367,7 +387,12 @@ async fn test_shopping_flow_with_session() {
     };
 
     let client = create_cookie_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -435,8 +460,18 @@ async fn test_client_without_cookies_fails_session() {
     // Client WITH cookies
     let client_with_cookies = create_cookie_client();
 
-    let executor_no_cookies = ScenarioExecutor::new(BASE_URL.to_string(), client_no_cookies, "test-node".to_string(), "run-0".to_string());
-    let executor_with_cookies = ScenarioExecutor::new(BASE_URL.to_string(), client_with_cookies, "test-node".to_string(), "run-0".to_string());
+    let executor_no_cookies = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client_no_cookies,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
+    let executor_with_cookies = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client_with_cookies,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
 
     let mut context_no_cookies = ScenarioContext::new();
     let mut context_with_cookies = ScenarioContext::new();

--- a/tests/csv_data_driven_tests.rs
+++ b/tests/csv_data_driven_tests.rs
@@ -156,7 +156,7 @@ async fn test_scenario_with_csv_data() {
     // Execute scenario twice with different data rows
     for i in 0..2 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
 
         let mut context = ScenarioContext::new();
         let row = ds.next_row().unwrap();
@@ -206,7 +206,7 @@ async fn test_multiple_users_different_data() {
 
     for i in 0..3 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
 
         let mut context = ScenarioContext::new();
         let row = ds.next_row().unwrap();
@@ -296,7 +296,7 @@ dave,dave012,dave@company.com,manager"#;
     // Simulate 8 virtual users (2 full cycles through 4 users)
     for i in 0..8 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(base_url.clone(), client);
+        let executor = ScenarioExecutor::new(base_url.clone(), client, "test-node".to_string(), "run-0".to_string());
 
         let mut context = ScenarioContext::new();
         let row = ds.next_row().unwrap();

--- a/tests/csv_data_driven_tests.rs
+++ b/tests/csv_data_driven_tests.rs
@@ -156,7 +156,12 @@ async fn test_scenario_with_csv_data() {
     // Execute scenario twice with different data rows
     for i in 0..2 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+        let executor = ScenarioExecutor::new(
+            BASE_URL.to_string(),
+            client,
+            "test-node".to_string(),
+            "run-0".to_string(),
+        );
 
         let mut context = ScenarioContext::new();
         let row = ds.next_row().unwrap();
@@ -206,7 +211,12 @@ async fn test_multiple_users_different_data() {
 
     for i in 0..3 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+        let executor = ScenarioExecutor::new(
+            BASE_URL.to_string(),
+            client,
+            "test-node".to_string(),
+            "run-0".to_string(),
+        );
 
         let mut context = ScenarioContext::new();
         let row = ds.next_row().unwrap();
@@ -296,7 +306,12 @@ dave,dave012,dave@company.com,manager"#;
     // Simulate 8 virtual users (2 full cycles through 4 users)
     for i in 0..8 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(base_url.clone(), client, "test-node".to_string(), "run-0".to_string());
+        let executor = ScenarioExecutor::new(
+            base_url.clone(),
+            client,
+            "test-node".to_string(),
+            "run-0".to_string(),
+        );
 
         let mut context = ScenarioContext::new();
         let row = ds.next_row().unwrap();

--- a/tests/error_categorization_tests.rs
+++ b/tests/error_categorization_tests.rs
@@ -189,7 +189,7 @@ async fn test_404_error_categorization() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -235,7 +235,7 @@ async fn test_timeout_error_categorization() {
         .build()
         .expect("Failed to create client");
 
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -275,6 +275,8 @@ async fn test_network_error_categorization() {
     let executor = ScenarioExecutor::new(
         "https://invalid-host-that-does-not-exist-12345.com".to_string(),
         client,
+        "test-node".to_string(),
+        "run-0".to_string(),
     );
     let mut context = ScenarioContext::new();
 
@@ -328,7 +330,7 @@ async fn test_mixed_error_types_in_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/error_categorization_tests.rs
+++ b/tests/error_categorization_tests.rs
@@ -189,7 +189,12 @@ async fn test_404_error_categorization() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -235,7 +240,12 @@ async fn test_timeout_error_categorization() {
         .build()
         .expect("Failed to create client");
 
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -330,7 +340,12 @@ async fn test_mixed_error_types_in_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/http_methods_tests.rs
+++ b/tests/http_methods_tests.rs
@@ -40,7 +40,12 @@ async fn test_get_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -84,7 +89,12 @@ async fn test_post_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -128,7 +138,12 @@ async fn test_put_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -170,7 +185,12 @@ async fn test_patch_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -208,7 +228,12 @@ async fn test_delete_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -246,7 +271,12 @@ async fn test_head_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -285,7 +315,12 @@ async fn test_options_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -401,7 +436,12 @@ async fn test_mixed_methods_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -473,7 +513,12 @@ async fn test_case_insensitive_methods() {
         };
 
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+        let executor = ScenarioExecutor::new(
+            server.uri(),
+            client,
+            "test-node".to_string(),
+            "run-0".to_string(),
+        );
         let mut context = ScenarioContext::new();
 
         let result = executor
@@ -595,7 +640,12 @@ async fn test_rest_crud_flow() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -647,7 +697,12 @@ async fn test_options_cors_preflight() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/http_methods_tests.rs
+++ b/tests/http_methods_tests.rs
@@ -40,7 +40,7 @@ async fn test_get_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -84,7 +84,7 @@ async fn test_post_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -128,7 +128,7 @@ async fn test_put_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -170,7 +170,7 @@ async fn test_patch_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -208,7 +208,7 @@ async fn test_delete_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -246,7 +246,7 @@ async fn test_head_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -285,7 +285,7 @@ async fn test_options_request() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -401,7 +401,7 @@ async fn test_mixed_methods_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -473,7 +473,7 @@ async fn test_case_insensitive_methods() {
         };
 
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(server.uri(), client);
+        let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
         let mut context = ScenarioContext::new();
 
         let result = executor
@@ -595,7 +595,7 @@ async fn test_rest_crud_flow() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -647,7 +647,7 @@ async fn test_options_cors_preflight() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,18 +21,18 @@ fn init_metrics() {
 }
 
 fn get_total_requests() -> u64 {
-    REQUEST_TOTAL.with_label_values(&["local", ""]).get()
+    REQUEST_TOTAL.with_label_values(&["local", "", "test-node", "run-0"]).get()
 }
 
 fn get_status_code_count(code: &str) -> u64 {
     REQUEST_STATUS_CODES
-        .with_label_values(&[code, "local", ""])
+        .with_label_values(&[code, "local", "", "test-node", "run-0"])
         .get()
 }
 
 fn get_duration_count() -> u64 {
     REQUEST_DURATION_SECONDS
-        .with_label_values(&["local", ""])
+        .with_label_values(&["local", "", "test-node", "run-0"])
         .get_sample_count()
 }
 
@@ -65,6 +65,8 @@ async fn worker_sends_get_requests() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -107,6 +109,8 @@ async fn worker_sends_post_requests() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -145,6 +149,8 @@ async fn worker_sends_json_post_body() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -182,6 +188,8 @@ async fn worker_tracks_200_status_codes() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -223,6 +231,8 @@ async fn worker_tracks_404_status_codes() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -264,6 +274,8 @@ async fn worker_tracks_500_status_codes() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -307,6 +319,8 @@ async fn worker_records_request_duration() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -348,6 +362,8 @@ async fn concurrent_requests_returns_to_zero_after_worker_finishes() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -355,7 +371,7 @@ async fn concurrent_requests_returns_to_zero_after_worker_finishes() {
     run_worker(client, config, Instant::now()).await;
 
     // After worker finishes, concurrent requests gauge should not be negative
-    let gauge = CONCURRENT_REQUESTS.with_label_values(&["local", ""]).get();
+    let gauge = CONCURRENT_REQUESTS.with_label_values(&["local", "", "test-node", "run-0"]).get();
     assert!(
         gauge >= 0.0,
         "concurrent requests gauge should not be negative, got {}",
@@ -385,6 +401,8 @@ async fn worker_handles_connection_error_gracefully() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -430,6 +448,8 @@ async fn worker_respects_rps_rate_limit() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -472,6 +492,8 @@ async fn worker_stops_after_test_duration() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 
@@ -521,6 +543,8 @@ async fn worker_handles_slow_responses() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
         stop_rx: tokio::sync::watch::channel(false).1,
     };
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -21,7 +21,9 @@ fn init_metrics() {
 }
 
 fn get_total_requests() -> u64 {
-    REQUEST_TOTAL.with_label_values(&["local", "", "test-node", "run-0"]).get()
+    REQUEST_TOTAL
+        .with_label_values(&["local", "", "test-node", "run-0"])
+        .get()
 }
 
 fn get_status_code_count(code: &str) -> u64 {
@@ -371,7 +373,9 @@ async fn concurrent_requests_returns_to_zero_after_worker_finishes() {
     run_worker(client, config, Instant::now()).await;
 
     // After worker finishes, concurrent requests gauge should not be negative
-    let gauge = CONCURRENT_REQUESTS.with_label_values(&["local", "", "test-node", "run-0"]).get();
+    let gauge = CONCURRENT_REQUESTS
+        .with_label_values(&["local", "", "test-node", "run-0"])
+        .get();
     assert!(
         gauge >= 0.0,
         "concurrent requests gauge should not be negative, got {}",

--- a/tests/per_scenario_throughput_tests.rs
+++ b/tests/per_scenario_throughput_tests.rs
@@ -178,7 +178,12 @@ async fn test_scenario_throughput_tracking() {
     // Execute scenario 5 times
     for _ in 0..5 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+        let executor = ScenarioExecutor::new(
+            BASE_URL.to_string(),
+            client,
+            "test-node".to_string(),
+            "run-0".to_string(),
+        );
         let mut context = ScenarioContext::new();
 
         let result = executor
@@ -259,7 +264,12 @@ async fn test_multiple_scenarios_different_throughput() {
     // Execute fast scenario 3 times
     for _ in 0..3 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+        let executor = ScenarioExecutor::new(
+            BASE_URL.to_string(),
+            client,
+            "test-node".to_string(),
+            "run-0".to_string(),
+        );
         let mut context = ScenarioContext::new();
 
         let result = executor
@@ -274,7 +284,12 @@ async fn test_multiple_scenarios_different_throughput() {
     // Execute slow scenario 2 times
     for _ in 0..2 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+        let executor = ScenarioExecutor::new(
+            BASE_URL.to_string(),
+            client,
+            "test-node".to_string(),
+            "run-0".to_string(),
+        );
         let mut context = ScenarioContext::new();
 
         let result = executor

--- a/tests/per_scenario_throughput_tests.rs
+++ b/tests/per_scenario_throughput_tests.rs
@@ -178,7 +178,7 @@ async fn test_scenario_throughput_tracking() {
     // Execute scenario 5 times
     for _ in 0..5 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
         let mut context = ScenarioContext::new();
 
         let result = executor
@@ -259,7 +259,7 @@ async fn test_multiple_scenarios_different_throughput() {
     // Execute fast scenario 3 times
     for _ in 0..3 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
         let mut context = ScenarioContext::new();
 
         let result = executor
@@ -274,7 +274,7 @@ async fn test_multiple_scenarios_different_throughput() {
     // Execute slow scenario 2 times
     for _ in 0..2 {
         let client = create_test_client();
-        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+        let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
         let mut context = ScenarioContext::new();
 
         let result = executor

--- a/tests/percentile_tracking_tests.rs
+++ b/tests/percentile_tracking_tests.rs
@@ -256,7 +256,12 @@ async fn test_scenario_percentile_tracking() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
 
     // Execute scenario multiple times
     for _ in 0..5 {

--- a/tests/percentile_tracking_tests.rs
+++ b/tests/percentile_tracking_tests.rs
@@ -256,7 +256,7 @@ async fn test_scenario_percentile_tracking() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
 
     // Execute scenario multiple times
     for _ in 0..5 {

--- a/tests/scenario_integration_tests.rs
+++ b/tests/scenario_integration_tests.rs
@@ -46,7 +46,12 @@ async fn test_health_check_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -96,7 +101,12 @@ async fn test_product_browsing_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -141,7 +151,12 @@ async fn test_variable_substitution() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
 
     let result = executor
         .execute(&scenario, &mut context, &mut SessionStore::new())
@@ -220,7 +235,12 @@ async fn test_multi_step_with_delays() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let start = std::time::Instant::now();
@@ -292,7 +312,12 @@ async fn test_scenario_failure_handling() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -345,7 +370,12 @@ async fn test_timestamp_variable() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -390,7 +420,12 @@ async fn test_post_request_with_json_body() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -428,7 +463,12 @@ async fn test_scenario_context_isolation() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
 
     // Execute scenario twice with different contexts
     let mut context1 = ScenarioContext::new();
@@ -485,7 +525,12 @@ async fn test_body_size_sends_correct_content_length() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(base_url, client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        base_url,
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/scenario_integration_tests.rs
+++ b/tests/scenario_integration_tests.rs
@@ -46,7 +46,7 @@ async fn test_health_check_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -96,7 +96,7 @@ async fn test_product_browsing_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -141,7 +141,7 @@ async fn test_variable_substitution() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
 
     let result = executor
         .execute(&scenario, &mut context, &mut SessionStore::new())
@@ -220,7 +220,7 @@ async fn test_multi_step_with_delays() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let start = std::time::Instant::now();
@@ -292,7 +292,7 @@ async fn test_scenario_failure_handling() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -345,7 +345,7 @@ async fn test_timestamp_variable() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -390,7 +390,7 @@ async fn test_post_request_with_json_body() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -428,7 +428,7 @@ async fn test_scenario_context_isolation() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
 
     // Execute scenario twice with different contexts
     let mut context1 = ScenarioContext::new();
@@ -485,7 +485,7 @@ async fn test_body_size_sends_correct_content_length() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(base_url, client);
+    let executor = ScenarioExecutor::new(base_url, client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/scenario_worker_tests.rs
+++ b/tests/scenario_worker_tests.rs
@@ -42,6 +42,8 @@ async fn test_scenario_worker_respects_duration() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
     };
 
     let client = reqwest::Client::new();
@@ -94,6 +96,8 @@ async fn test_scenario_worker_constant_load() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
     };
 
     let client = reqwest::Client::new();
@@ -153,6 +157,8 @@ async fn test_scenario_worker_with_think_time() {
         percentile_sampling_rate: 100,
         region: "local".to_string(),
         tenant: String::new(),
+        node_id: "test-node".to_string(),
+        run_id: "run-0".to_string(),
     };
 
     let client = reqwest::Client::new();

--- a/tests/think_time_tests.rs
+++ b/tests/think_time_tests.rs
@@ -75,7 +75,7 @@ async fn test_fixed_think_time() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
@@ -164,7 +164,7 @@ async fn test_random_think_time() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
 
     // Run multiple times to test randomness
     let mut durations = Vec::new();
@@ -257,7 +257,7 @@ async fn test_multiple_think_times() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
@@ -337,7 +337,7 @@ async fn test_no_think_time() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
@@ -425,7 +425,7 @@ async fn test_realistic_user_behavior() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client);
+    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();

--- a/tests/think_time_tests.rs
+++ b/tests/think_time_tests.rs
@@ -75,7 +75,12 @@ async fn test_fixed_think_time() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
@@ -164,7 +169,12 @@ async fn test_random_think_time() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
 
     // Run multiple times to test randomness
     let mut durations = Vec::new();
@@ -257,7 +267,12 @@ async fn test_multiple_think_times() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
@@ -337,7 +352,12 @@ async fn test_no_think_time() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();
@@ -425,7 +445,12 @@ async fn test_realistic_user_behavior() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(server.uri(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        server.uri(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let start = Instant::now();

--- a/tests/variable_extraction_tests.rs
+++ b/tests/variable_extraction_tests.rs
@@ -51,7 +51,7 @@ async fn test_jsonpath_extraction_from_products() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -116,7 +116,7 @@ async fn test_extraction_and_reuse_in_next_step() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -165,7 +165,7 @@ async fn test_header_extraction() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -223,7 +223,7 @@ async fn test_multiple_extractions_in_single_step() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -324,7 +324,7 @@ async fn test_shopping_flow_with_extraction() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -394,7 +394,7 @@ async fn test_extraction_failure_doesnt_stop_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client);
+    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
     let mut context = ScenarioContext::new();
 
     let result = executor

--- a/tests/variable_extraction_tests.rs
+++ b/tests/variable_extraction_tests.rs
@@ -51,7 +51,12 @@ async fn test_jsonpath_extraction_from_products() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -116,7 +121,12 @@ async fn test_extraction_and_reuse_in_next_step() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -165,7 +175,12 @@ async fn test_header_extraction() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -223,7 +238,12 @@ async fn test_multiple_extractions_in_single_step() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -324,7 +344,12 @@ async fn test_shopping_flow_with_extraction() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor
@@ -394,7 +419,12 @@ async fn test_extraction_failure_doesnt_stop_scenario() {
     };
 
     let client = create_test_client();
-    let executor = ScenarioExecutor::new(BASE_URL.to_string(), client, "test-node".to_string(), "run-0".to_string());
+    let executor = ScenarioExecutor::new(
+        BASE_URL.to_string(),
+        client,
+        "test-node".to_string(),
+        "run-0".to_string(),
+    );
     let mut context = ScenarioContext::new();
 
     let result = executor


### PR DESCRIPTION
## Summary

This PR merges `dev` into `main`, bringing in all work from Phase 2 through Phase 4.

### Phase 2 — Advanced Configuration System
- YAML config parser with schema validation, versioning, and migration (#37–#41)
- Environment variable overrides with precedence (#40)
- Multi-scenario execution engine with weighted selection (#43)
- CSV data-driven testing (#31), all HTTP methods (#32), response assertions (#30)
- Variable extraction from JSON/regex/header responses (#27)
- Cookie and session management (#28), configurable think times (#29)
- Per-scenario throughput tracking (#35), percentile latency tracking (#33)
- Error categorization (client/server/network/timeout/TLS) (#34)
- Connection pool statistics (#36)

### Phase 3 — Cluster & Observability
- Multi-region cluster infrastructure with region-labeled metrics (#45)
- gRPC worker communication protocol (#46)
- Raft leader election and coordination (#47)
- Periodic histogram rotation (#67), MAX_HISTOGRAM_LABELS memory guard (#68)
- PERCENTILE_SAMPLING_RATE for high-RPS tests (#70), auto-OOM protection (#72)
- OOM-safe body streaming to prevent memory accumulation (#73, #74)
- Per-step Prometheus metrics (#90), tenant label scoping (#91)

### Phase 4 — Standalone Mode
- Remove Raft consensus layer — every node operates independently (#82)
- `POST /config` accepts YAML, `GET /health` returns live test state (#82, #84, #85, #86)
- Ephemeral node support with final-scrape delay before self-destruct (#97, #98)
- API auth token + `POST /stop` endpoint (#91, #93)
- Node auto-registration with webload-gui control plane (#89)
- Body size field for synthetic large-payload testing (#96)
- Multi-host steps — full URL override in path field
- Tenant env var at startup; periodic re-registration replaced with once-at-startup (#104)
- **`node_id` and `run_id` labels on all request and scenario metrics** (#106)
- Debian/musl static binary Docker image, structured JSON logging (#101)
- Nomad job definitions and Consul KV config examples

## Test plan
- [ ] CI passes on this PR (all unit + integration tests via GitHub Actions)
- [ ] `GET /health` returns `node_id`, `run_id`, state, rps, memory fields
- [ ] `POST /config` with a dual-host YAML (relative path + full URL path) routes correctly
- [ ] Prometheus metrics include `node_id` and `run_id` labels on all time series
- [ ] `cargo test` locally passes (or verify via CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)