### PR TITLE
feat: resolveTargetAddr YAML field, URL double-slash fix, node_id/run_id metrics labels

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -199,8 +199,10 @@ impl Config {
             None
         };
 
-        // Optional fields from env vars only (not in YAML yet)
-        let resolve_target_addr = env::var("RESOLVE_TARGET_ADDR").ok();
+        // RESOLVE_TARGET_ADDR: env var wins; fall back to YAML resolveTargetAddr
+        let resolve_target_addr = env::var("RESOLVE_TARGET_ADDR")
+            .ok()
+            .or_else(|| yaml_config.config.resolve_target_addr.clone());
         let client_cert_path = env::var("CLIENT_CERT_PATH").ok();
         let client_key_path = env::var("CLIENT_KEY_PATH").ok();
 
@@ -292,7 +294,9 @@ impl Config {
         } else {
             None
         };
-        let resolve_target_addr = env::var("RESOLVE_TARGET_ADDR").ok();
+        let resolve_target_addr = env::var("RESOLVE_TARGET_ADDR")
+            .ok()
+            .or_else(|| yaml_config.config.resolve_target_addr.clone());
         let client_cert_path = env::var("CLIENT_CERT_PATH").ok();
         let client_key_path = env::var("CLIENT_KEY_PATH").ok();
         let percentile_tracking_enabled = env_bool("PERCENTILE_TRACKING_ENABLED", true);

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -289,7 +289,9 @@ impl ScenarioExecutor {
         let url = if path.starts_with("http://") || path.starts_with("https://") {
             path
         } else {
-            format!("{}{}", self.base_url, path)
+            let base = self.base_url.trim_end_matches('/');
+            let p = path.trim_start_matches('/');
+            format!("{}/{}", base, p)
         };
 
         debug!(

--- a/src/yaml_config.rs
+++ b/src/yaml_config.rs
@@ -93,6 +93,12 @@ pub struct YamlGlobalConfig {
 
     #[serde(rename = "customHeaders")]
     pub custom_headers: Option<String>,
+
+    /// DNS override: force hostname to resolve to a specific IP.
+    /// Format: "hostname:ip:port"  e.g. "api.example.com:1.2.3.4:443"
+    /// Equivalent to the RESOLVE_TARGET_ADDR env var; env var takes precedence.
+    #[serde(rename = "resolveTargetAddr")]
+    pub resolve_target_addr: Option<String>,
 }
 
 fn default_timeout() -> YamlDuration {

--- a/src/yaml_config.rs
+++ b/src/yaml_config.rs
@@ -722,6 +722,7 @@ impl Default for YamlConfig {
                 duration: YamlDuration::Seconds(60),
                 skip_tls_verify: false,
                 custom_headers: None,
+                resolve_target_addr: None,
             },
             load: YamlLoadModel::Concurrent,
             scenarios: vec![],


### PR DESCRIPTION
## Summary

Three changes in this release:

### 1. `resolveTargetAddr` — DNS override via `POST /config`
DNS pinning can now be configured per-test via the YAML body sent to `POST /config`.
Previously this required setting `RESOLVE_TARGET_ADDR` as a node-level env var and restarting the service.

```yaml
config:
  baseUrl: "https://api.example.com"
  resolveTargetAddr: "api.example.com:34.117.247.4:443"
```

Format: `"hostname:ip:port"`. Env var `RESOLVE_TARGET_ADDR` still takes precedence when both are set.

### 2. Double-slash URL fix
`baseUrl` ending in `/` combined with a `path` starting with `/` previously produced double slashes in the request URL (e.g. `https://api.example.com/v2//resource`). Both sides are now trimmed before joining.

Full URLs in the `path` field (`https://other-host.com/...`) are unaffected and bypass base URL joining entirely.

### 3. `node_id` + `run_id` labels on all metrics (closes #106)
All 12 Prometheus metrics now carry `node_id` and `run_id` labels for per-node and per-run filtering in Grafana.

---

## Files changed

| File | Change |
|------|--------|
| `src/yaml_config.rs` | Add `resolveTargetAddr` field to `YamlGlobalConfig` |
| `src/config.rs` | Wire `resolveTargetAddr` through both config paths (env var wins) |
| `src/executor.rs` | Trim trailing `/` from base and leading `/` from path before joining |
| `src/worker.rs` | Add `node_id` + `run_id` label values to all metrics |
| `src/metrics.rs` | Declare `node_id` + `run_id` label slots on all 12 metrics |

## Test plan

- [ ] `POST /config` with `resolveTargetAddr` routes requests to the specified IP
- [ ] `RESOLVE_TARGET_ADDR` env var overrides `resolveTargetAddr` when both are set
- [ ] `baseUrl: "https://api.example.com/"` + `path: "/endpoint"` → no double slash
- [ ] Full URL in `path` bypasses base URL entirely
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)