### PR TITLE
fix: workers running past duration + POST /config race condition (closes #109, #110)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,191 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: cbaugus/rust_loadtest
+
+jobs:
+  # ── 1. Lint ────────────────────────────────────────────────────────────────
+  lint:
+    name: Lint (rustfmt & clippy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: lint
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  # ── 2. Test ────────────────────────────────────────────────────────────────
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: test
+
+      - name: Run unit tests
+        run: cargo test --lib --all-features --verbose -- --test-threads=1
+        timeout-minutes: 10
+
+      - name: Run integration tests
+        run: cargo test --test '*' --all-features --verbose -- --test-threads=1
+        timeout-minutes: 10
+
+  # ── 3. Build & publish Docker images ──────────────────────────────────────
+  build-and-release:
+    name: Build, Push & Release
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    timeout-minutes: 30
+    permissions:
+      contents: write   # needed to create GitHub releases
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Strip the leading 'v' to get a bare semver (e.g. v1.5.3 → 1.5.3)
+      - name: Derive version strings
+        id: version
+        run: |
+          TAG="${{ github.ref_name }}"
+          SEMVER="${TAG#v}"
+          echo "tag=${TAG}"       >> $GITHUB_OUTPUT
+          echo "semver=${SEMVER}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # ── Standard image ──────────────────────────────────────────────────
+      - name: Build standard image (load for SBOM)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
+          push: false
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ── Chainguard image ─────────────────────────────────────────────────
+      - name: Build Chainguard image (load for SBOM)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.chainguard
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}-Chainguard
+          push: false
+          load: true
+          cache-from: type=gha
+
+      # ── SBOMs ─────────────────────────────────────────────────────────────
+      - name: Install Syft
+        run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Generate SBOM — standard
+        run: |
+          syft "docker:${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}" \
+            -o cyclonedx-json > sbom-standard.cyclonedx.json
+
+      - name: Generate SBOM — Chainguard
+        run: |
+          syft "docker:${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}-Chainguard" \
+            -o cyclonedx-json > sbom-chainguard.cyclonedx.json
+
+      # ── Push standard: version tag + latest ───────────────────────────────
+      - name: Push standard image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
+            ${{ env.IMAGE_NAME }}:latest
+          provenance: true
+          push: true
+          cache-from: type=gha
+
+      # ── Push Chainguard: version tag + latest-Chainguard ─────────────────
+      - name: Push Chainguard image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.chainguard
+          platforms: linux/amd64
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}-Chainguard
+            ${{ env.IMAGE_NAME }}:latest-Chainguard
+          provenance: true
+          push: true
+          cache-from: type=gha
+
+      # ── Update Docker Hub repository description ──────────────────────────
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}
+          readme-filepath: ./DOCKER_HUB_OVERVIEW.md
+
+      # ── GitHub Release ────────────────────────────────────────────────────
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
+          files: |
+            sbom-standard.cyclonedx.json
+            sbom-chainguard.cyclonedx.json
+          body: |
+            ## Docker images
+
+            | Variant | Pull command |
+            |---------|-------------|
+            | Standard (Ubuntu) | `docker pull ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}` |
+            | Chainguard (minimal) | `docker pull ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}-Chainguard` |
+
+            `latest` and `latest-Chainguard` are also updated to this release.
+
+            ## SBOMs
+            CycloneDX SBOMs for both images are attached to this release.

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,6 +15,8 @@ pub struct ClientConfig {
     pub client_key_path: Option<String>,
     pub custom_headers: Option<String>,
     pub pool_config: Option<PoolConfig>,
+    /// Enable per-request cookie jar (required for scenario session isolation).
+    pub cookie_store: bool,
 }
 
 /// Result of building the client, includes parsed headers for logging.
@@ -59,6 +61,11 @@ pub fn build_client(
         "Connection pool configured: max_idle_per_host={}, idle_timeout={:?}",
         pool_config.max_idle_per_host, pool_config.idle_timeout
     );
+
+    // Cookie store for session isolation (scenario workers)
+    if config.cookie_store {
+        client_builder = client_builder.cookie_store(true);
+    }
 
     // Build client with TLS settings
     let client = if config.skip_tls_verify {

--- a/src/config.rs
+++ b/src/config.rs
@@ -719,6 +719,7 @@ impl Config {
             client_key_path: self.client_key_path.clone(),
             custom_headers: self.custom_headers.clone(),
             pool_config: Some(crate::connection_pool::PoolConfig::from_env()),
+            cookie_store: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1116,6 +1116,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     "Config submitted via POST /config — draining worker pool"
                 );
 
+                // Bump generation first — invalidates any in-flight completion watcher
+                // so it exits at Check 2 rather than re-spawning standby workers on top
+                // of the workers we are about to start.
+                {
+                    let mut ts = test_state_for_watcher.lock().unwrap();
+                    ts.generation += 1;
+                }
                 // Signal graceful stop (workers exit after current request).
                 {
                     let state = pool_for_watcher.lock().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1186,9 +1186,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                                         node_id: node_id_for_watcher.clone(),
                                         run_id: new_run_id.clone(),
                                         skip_tls_verify: new_cfg.skip_tls_verify,
-                                        resolve_target_addr: new_cfg
-                                            .resolve_target_addr
-                                            .clone(),
+                                        resolve_target_addr: new_cfg.resolve_target_addr.clone(),
                                     };
                                     tokio::spawn(run_scenario_worker(sc, new_start))
                                 })

--- a/src/main.rs
+++ b/src/main.rs
@@ -1185,12 +1185,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                                         tenant: new_tenant.clone().unwrap_or_default(),
                                         node_id: node_id_for_watcher.clone(),
                                         run_id: new_run_id.clone(),
+                                        skip_tls_verify: new_cfg.skip_tls_verify,
+                                        resolve_target_addr: new_cfg
+                                            .resolve_target_addr
+                                            .clone(),
                                     };
-                                    tokio::spawn(run_scenario_worker(
-                                        new_client.clone(),
-                                        sc,
-                                        new_start,
-                                    ))
+                                    tokio::spawn(run_scenario_worker(sc, new_start))
                                 })
                                 .collect()
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -714,12 +714,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Startup standby config: fallback when a test YAML has no `standby:` block.
     // Nodes auto-revert to their startup state (typically TARGET_RPS=0) after a test ends.
     let startup_standby: Arc<StandbyRunConfig> = Arc::new(StandbyRunConfig {
-        workers: config.num_concurrent_tasks,
-        rps: if let LoadModel::Rps { target_rps } = &config.load_model {
-            *target_rps
-        } else {
-            0.0
-        },
+        workers: 2,
+        rps: 0.0,
         url: config.target_url.clone(),
         request_type: config.request_type.clone(),
         send_json: config.send_json,
@@ -1474,7 +1470,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                         (None, None, None)
                     };
                     (
-                        remaining as i64,
+                        (remaining as i64).max(0),
                         ts.yaml.clone(),
                         ts.node_state.to_string(),
                         started_at,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -20,6 +20,7 @@ fn should_sample(rate: u8) -> bool {
     counter % 100 < rate as u64
 }
 
+use crate::client::{build_client, ClientConfig};
 use crate::connection_pool::GLOBAL_POOL_STATS;
 use crate::errors::ErrorCategory;
 use crate::executor::{ScenarioExecutor, SessionStore};
@@ -375,6 +376,10 @@ pub struct ScenarioWorkerConfig {
     pub node_id: String,
     /// Run identifier (Issue #106). Unique per test dispatch.
     pub run_id: String,
+    /// Skip TLS certificate verification (propagated from global config).
+    pub skip_tls_verify: bool,
+    /// DNS override string in `hostname:ip:port` format (propagated from global config).
+    pub resolve_target_addr: Option<String>,
 }
 
 /// Runs a scenario-based worker task that executes multi-step scenarios according to the load model.
@@ -384,13 +389,10 @@ pub struct ScenarioWorkerConfig {
 ///
 /// # Cookie and Session Management
 ///
-/// For proper session isolation, each scenario execution gets its own cookie-enabled
-/// HTTP client. This ensures cookies from one virtual user don't leak to another.
-pub async fn run_scenario_worker(
-    _client: reqwest::Client, // Ignored - we create per-execution clients
-    config: ScenarioWorkerConfig,
-    start_time: Instant,
-) {
+/// Each scenario execution gets its own cookie-enabled HTTP client built from the
+/// worker config (DNS override, TLS settings). This ensures cookies from one virtual
+/// user don't leak to another while preserving global client settings.
+pub async fn run_scenario_worker(config: ScenarioWorkerConfig, start_time: Instant) {
     debug!(
         task_id = config.task_id,
         scenario = %config.scenario.name,
@@ -417,6 +419,23 @@ pub async fn run_scenario_worker(
     // Steps with `cache: { ttl }` store their extracted variables here so
     // subsequent iterations skip the HTTP request until the TTL expires.
     let mut session = SessionStore::new();
+
+    // Build the HTTP client once per worker with DNS override, TLS, and cookie store enabled.
+    // Building once avoids log flooding and expensive reconstruction on every loop iteration.
+    let worker_client = build_client(&ClientConfig {
+        skip_tls_verify: config.skip_tls_verify,
+        resolve_target_addr: config.resolve_target_addr.clone(),
+        client_cert_path: None,
+        client_key_path: None,
+        custom_headers: None,
+        pool_config: None,
+        cookie_store: true,
+    })
+    .map(|r| r.client)
+    .unwrap_or_else(|e| {
+        error!(error = %e, "Failed to build scenario worker client; falling back to default");
+        reqwest::Client::new()
+    });
 
     loop {
         time::sleep_until(next_fire).await;
@@ -450,18 +469,10 @@ pub async fn run_scenario_worker(
             continue;
         }
 
-        // Create new cookie-enabled client for this virtual user
-        // This ensures cookie isolation between scenario executions
-        let client = reqwest::Client::builder()
-            .cookie_store(true) // Enable automatic cookie management
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
-
-        // Create executor with isolated client
+        // Create executor with the worker's configured client
         let executor = ScenarioExecutor::new(
             config.base_url.clone(),
-            client,
+            worker_client.clone(),
             config.node_id.clone(),
             config.run_id.clone(),
         );

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -142,6 +142,8 @@ pub async fn run_worker(client: reqwest::Client, config: WorkerConfig, start_tim
             // immediately next iteration (Concurrent) or we set a long pause (0 RPS).
             if current_target_rps == 0.0 {
                 next_fire = now + Duration::from_secs(3600);
+                // rps=0 means idle standby — skip request entirely and wait for the next cycle.
+                continue;
             }
             // For Concurrent (f64::MAX), next_fire stays in the past → fires immediately.
         }
@@ -444,6 +446,8 @@ pub async fn run_scenario_worker(
             next_fire += Duration::from_millis(cycle_ms);
         } else if current_target_sps == 0.0 {
             next_fire = now + Duration::from_secs(3600);
+            // rps=0 means idle standby — skip scenario execution entirely and wait for the next cycle.
+            continue;
         }
 
         // Create new cookie-enabled client for this virtual user

--- a/tests/scenario_worker_tests.rs
+++ b/tests/scenario_worker_tests.rs
@@ -44,14 +44,15 @@ async fn test_scenario_worker_respects_duration() {
         tenant: String::new(),
         node_id: "test-node".to_string(),
         run_id: "run-0".to_string(),
+        skip_tls_verify: false,
+        resolve_target_addr: None,
     };
 
-    let client = reqwest::Client::new();
     let start_time = Instant::now();
 
     // Run worker
     let worker_start = Instant::now();
-    run_scenario_worker(client, config, start_time).await;
+    run_scenario_worker(config, start_time).await;
     let worker_duration = worker_start.elapsed();
 
     // Worker should stop after ~2 seconds
@@ -98,12 +99,13 @@ async fn test_scenario_worker_constant_load() {
         tenant: String::new(),
         node_id: "test-node".to_string(),
         run_id: "run-0".to_string(),
+        skip_tls_verify: false,
+        resolve_target_addr: None,
     };
 
-    let client = reqwest::Client::new();
     let start_time = Instant::now();
 
-    run_scenario_worker(client, config, start_time).await;
+    run_scenario_worker(config, start_time).await;
 
     // Just verify it completes without panicking
     // Actual scenario count would need metrics tracking to verify
@@ -159,13 +161,14 @@ async fn test_scenario_worker_with_think_time() {
         tenant: String::new(),
         node_id: "test-node".to_string(),
         run_id: "run-0".to_string(),
+        skip_tls_verify: false,
+        resolve_target_addr: None,
     };
 
-    let client = reqwest::Client::new();
     let start_time = Instant::now();
 
     let worker_start = Instant::now();
-    run_scenario_worker(client, config, start_time).await;
+    run_scenario_worker(config, start_time).await;
     let worker_duration = worker_start.elapsed();
 
     // Should take at least 2 seconds (test duration)


### PR DESCRIPTION
## Summary

Fixes two bugs in worker lifecycle management, plus a follow-on fix discovered during integration testing.

### #109 — Workers keep running past TEST_DURATION

Three fixes:

1. **Clamp `time_remaining_secs` to 0** — `/health` was reporting negative values after the test ended. The computed `duration - elapsed` is now clamped with `.max(0)`.

2. **Correct standby worker count** — `startup_standby` was initialised from `config.num_concurrent_tasks` (the test worker count, e.g. 300). After a test ends with no `standby:` YAML block, the fallback standby was spawning 300 workers instead of a sensible idle default. Fixed to `workers: 2, rps: 0.0`.

3. **`rps: 0` now means idle** — Standby workers with `target_rps == 0.0` were advancing `next_fire` by 1 hour but then falling through and executing the request anyway. Added `continue` to skip the request body entirely, so workers sleep without generating traffic.

### #110 — POST /config does not update workers/RPS on persistent node

**Race condition fix** — The config-watcher now bumps `test_state.generation` *before* sending the stop signal and draining workers. Previously, an in-flight `spawn_completion_watcher` could pass its Check 1 generation guard, sleep through the 5 s drain window, and then re-spawn stale standby workers on top of the newly-configured test workers. With the generation bumped early, the completion watcher sees a stale generation at Check 2 and exits cleanly.

### #113 — Scenario workers ignore DNS override and TLS settings

**Root cause** — `run_scenario_worker` accepted a configured `reqwest::Client` as its first parameter but named it `_client` and ignored it, building a plain default client on every loop iteration instead. This meant `resolveTargetAddr` and `skipTlsVerify` set via `POST /config` were silently dropped, causing all scenario requests to fail with connection errors when the target is only reachable via the DNS override.

**Fix** — Removed the unused `_client` parameter; added `skip_tls_verify` and `resolve_target_addr` to `ScenarioWorkerConfig`; build a single properly-configured client (DNS + TLS + cookie store) once per worker before the loop using `build_client`.

## Files changed

| File | Change |
|------|--------|
| `src/main.rs` | Clamp `time_remaining_secs`; fix `startup_standby` defaults; generation bump before drain; wire `skip_tls_verify`/`resolve_target_addr` into `ScenarioWorkerConfig` |
| `src/worker.rs` | Skip request when `target_rps == 0.0`; remove `_client` param; add TLS/DNS fields to `ScenarioWorkerConfig`; build configured client once per worker |
| `src/client.rs` | Add `cookie_store: bool` to `ClientConfig` |
| `src/config.rs` | Set `cookie_store: false` in `to_client_config()` |

## Test plan

- [ ] Start node with `TEST_DURATION=2m` — confirm workers stop and `/health` shows `time_remaining_secs: 0` (not negative) after test ends
- [ ] Confirm standby shows `workers: 2` not the original test count after transition
- [ ] Confirm no outbound requests during standby (`rps: 0` in standby block)
- [ ] `POST /config` on a node in standby — confirm new worker count and RPS take effect immediately
- [ ] `POST /config` with `resolveTargetAddr` — confirm scenario requests reach the correct host (check docker logs for DNS override message, confirm no `network_error` in metrics)
- [ ] `POST /config` with `skipTlsVerify: true` — confirm requests succeed against self-signed cert endpoint
- [ ] CI passes

Closes #109, #110, #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)